### PR TITLE
add-on to RD-9167: Define a specific CSV writer exception

### DIFF
--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/CsvIterableWriterNode.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/CsvIterableWriterNode.java
@@ -24,6 +24,7 @@ import raw.runtime.truffle.ExpressionNode;
 import raw.runtime.truffle.RawContext;
 import raw.runtime.truffle.StatementNode;
 import raw.runtime.truffle.runtime.exceptions.RawTruffleRuntimeException;
+import raw.runtime.truffle.runtime.exceptions.csv.CsvWriterRawTruffleException;
 import raw.runtime.truffle.runtime.generator.GeneratorLibrary;
 import raw.runtime.truffle.runtime.iterable.IterableLibrary;
 
@@ -66,7 +67,7 @@ public class CsvIterableWriterNode extends StatementNode {
                 itemWriter.call(item, gen);
             }
         } catch (IOException e) {
-            throw new RawTruffleRuntimeException(e.getMessage());
+            throw new CsvWriterRawTruffleException(e.getMessage(), e, this);
         }
     }
 
@@ -87,8 +88,8 @@ public class CsvIterableWriterNode extends StatementNode {
             generator.setSchema(schemaBuilder.build());
             generator.enable(STRICT_CHECK_FOR_QUOTING);
             return generator;
-        } catch (IOException ex) {
-            throw new RawTruffleRuntimeException(ex, this);
+        } catch (IOException e) {
+            throw new CsvWriterRawTruffleException(e.getMessage(), e, this);
         }
     }
 

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/CsvListWriterNode.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/CsvListWriterNode.java
@@ -24,6 +24,7 @@ import raw.runtime.truffle.ExpressionNode;
 import raw.runtime.truffle.RawContext;
 import raw.runtime.truffle.StatementNode;
 import raw.runtime.truffle.runtime.exceptions.RawTruffleRuntimeException;
+import raw.runtime.truffle.runtime.exceptions.csv.CsvWriterRawTruffleException;
 import raw.runtime.truffle.runtime.list.ListLibrary;
 import raw.runtime.truffle.runtime.list.ObjectList;
 
@@ -62,7 +63,7 @@ public class CsvListWriterNode extends StatementNode {
                 itemWriter.call(item, gen);
             }
         } catch (IOException e) {
-            throw new RawTruffleRuntimeException(e.getMessage());
+            throw new CsvWriterRawTruffleException(e.getMessage(), e, this);
         }
     }
 
@@ -83,8 +84,8 @@ public class CsvListWriterNode extends StatementNode {
             generator.setSchema(schemaBuilder.build());
             generator.enable(STRICT_CHECK_FOR_QUOTING);
             return generator;
-        } catch (IOException ex) {
-            throw new RawTruffleRuntimeException(ex, this);
+        } catch (IOException e) {
+            throw new CsvWriterRawTruffleException(e.getMessage(), e, this);
         }
     }
 

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/internal/BoolWriteCsvNode.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/internal/BoolWriteCsvNode.java
@@ -18,6 +18,7 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.NodeInfo;
 import raw.runtime.truffle.StatementNode;
 import raw.runtime.truffle.runtime.exceptions.RawTruffleRuntimeException;
+import raw.runtime.truffle.runtime.exceptions.csv.CsvWriterRawTruffleException;
 
 import java.io.IOException;
 
@@ -37,7 +38,7 @@ public class BoolWriteCsvNode extends StatementNode {
         try {
             gen.writeBoolean(value);
         } catch (IOException e) {
-            throw new RawTruffleRuntimeException(e.getMessage());
+            throw new CsvWriterRawTruffleException(e.getMessage(), e, this);
         }
     }
 }

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/internal/ByteWriteCsvNode.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/internal/ByteWriteCsvNode.java
@@ -18,6 +18,7 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.NodeInfo;
 import raw.runtime.truffle.StatementNode;
 import raw.runtime.truffle.runtime.exceptions.RawTruffleRuntimeException;
+import raw.runtime.truffle.runtime.exceptions.csv.CsvWriterRawTruffleException;
 
 import java.io.IOException;
 
@@ -37,7 +38,7 @@ public class ByteWriteCsvNode extends StatementNode {
         try {
             gen.writeNumber(value);
         } catch (IOException e) {
-            throw new RawTruffleRuntimeException(e.getMessage());
+            throw new CsvWriterRawTruffleException(e.getMessage(), e, this);
         }
     }
 }

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/internal/DateWriteCsvNode.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/internal/DateWriteCsvNode.java
@@ -18,6 +18,7 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.NodeInfo;
 import raw.runtime.truffle.StatementNode;
 import raw.runtime.truffle.runtime.exceptions.RawTruffleRuntimeException;
+import raw.runtime.truffle.runtime.exceptions.csv.CsvWriterRawTruffleException;
 import raw.runtime.truffle.runtime.primitives.DateObject;
 
 import java.io.IOException;
@@ -41,7 +42,7 @@ public class DateWriteCsvNode extends StatementNode {
         try {
             gen.writeString(formatter.format(value.getDate()));
         } catch (IOException e) {
-            throw new RawTruffleRuntimeException(e.getMessage());
+            throw new CsvWriterRawTruffleException(e.getMessage(), e, this);
         }
     }
 }

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/internal/DecimalWriteCsvNode.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/internal/DecimalWriteCsvNode.java
@@ -18,6 +18,7 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.NodeInfo;
 import raw.runtime.truffle.StatementNode;
 import raw.runtime.truffle.runtime.exceptions.RawTruffleRuntimeException;
+import raw.runtime.truffle.runtime.exceptions.csv.CsvWriterRawTruffleException;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -38,7 +39,7 @@ public class DecimalWriteCsvNode extends StatementNode {
         try {
             gen.writeNumber(value);
         } catch (IOException e) {
-            throw new RawTruffleRuntimeException(e.getMessage());
+            throw new CsvWriterRawTruffleException(e.getMessage(), e, this);
         }
     }
 }

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/internal/DoubleWriteCsvNode.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/internal/DoubleWriteCsvNode.java
@@ -18,6 +18,7 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.NodeInfo;
 import raw.runtime.truffle.StatementNode;
 import raw.runtime.truffle.runtime.exceptions.RawTruffleRuntimeException;
+import raw.runtime.truffle.runtime.exceptions.csv.CsvWriterRawTruffleException;
 
 import java.io.IOException;
 
@@ -37,7 +38,7 @@ public class DoubleWriteCsvNode extends StatementNode {
         try {
             gen.writeNumber(value);
         } catch (IOException e) {
-            throw new RawTruffleRuntimeException(e.getMessage());
+            throw new CsvWriterRawTruffleException(e.getMessage(), e, this);
         }
     }
 }

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/internal/FloatWriteCsvNode.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/internal/FloatWriteCsvNode.java
@@ -18,6 +18,7 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.NodeInfo;
 import raw.runtime.truffle.StatementNode;
 import raw.runtime.truffle.runtime.exceptions.RawTruffleRuntimeException;
+import raw.runtime.truffle.runtime.exceptions.csv.CsvWriterRawTruffleException;
 
 import java.io.IOException;
 
@@ -37,7 +38,7 @@ public class FloatWriteCsvNode extends StatementNode {
         try {
             gen.writeNumber(value);
         } catch (IOException e) {
-            throw new RawTruffleRuntimeException(e.getMessage());
+            throw new CsvWriterRawTruffleException(e.getMessage(), e, this);
         }
     }
 }

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/internal/IntWriteCsvNode.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/internal/IntWriteCsvNode.java
@@ -18,6 +18,7 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.NodeInfo;
 import raw.runtime.truffle.StatementNode;
 import raw.runtime.truffle.runtime.exceptions.RawTruffleRuntimeException;
+import raw.runtime.truffle.runtime.exceptions.csv.CsvWriterRawTruffleException;
 
 import java.io.IOException;
 
@@ -37,7 +38,7 @@ public class IntWriteCsvNode extends StatementNode {
         try {
             gen.writeNumber(value);
         } catch (IOException e) {
-            throw new RawTruffleRuntimeException(e.getMessage());
+            throw new CsvWriterRawTruffleException(e.getMessage(), e, this);
         }
     }
 }

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/internal/LongWriteCsvNode.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/internal/LongWriteCsvNode.java
@@ -18,6 +18,7 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.NodeInfo;
 import raw.runtime.truffle.StatementNode;
 import raw.runtime.truffle.runtime.exceptions.RawTruffleRuntimeException;
+import raw.runtime.truffle.runtime.exceptions.csv.CsvWriterRawTruffleException;
 
 import java.io.IOException;
 
@@ -37,7 +38,7 @@ public class LongWriteCsvNode extends StatementNode {
         try {
             gen.writeNumber(value);
         } catch (IOException e) {
-            throw new RawTruffleRuntimeException(e.getMessage());
+            throw new CsvWriterRawTruffleException(e.getMessage(), e, this);
         }
     }
 }

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/internal/NullableWriteCsvNode.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/internal/NullableWriteCsvNode.java
@@ -20,6 +20,7 @@ import com.oracle.truffle.api.nodes.NodeInfo;
 import raw.runtime.truffle.StatementNode;
 import raw.runtime.truffle.ast.ProgramStatementNode;
 import raw.runtime.truffle.runtime.exceptions.RawTruffleRuntimeException;
+import raw.runtime.truffle.runtime.exceptions.csv.CsvWriterRawTruffleException;
 import raw.runtime.truffle.runtime.option.OptionLibrary;
 
 import java.io.IOException;
@@ -54,7 +55,7 @@ public class NullableWriteCsvNode extends StatementNode {
         try {
             gen.writeString("null");
         } catch (IOException e) {
-            throw new RawTruffleRuntimeException(e.getMessage());
+            throw new CsvWriterRawTruffleException(e.getMessage(), e, this);
         }
     }
 }

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/internal/RecordWriteCsvNode.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/internal/RecordWriteCsvNode.java
@@ -24,6 +24,7 @@ import com.oracle.truffle.api.nodes.NodeInfo;
 import raw.runtime.truffle.StatementNode;
 import raw.runtime.truffle.ast.ProgramStatementNode;
 import raw.runtime.truffle.runtime.exceptions.RawTruffleRuntimeException;
+import raw.runtime.truffle.runtime.exceptions.csv.CsvWriterRawTruffleException;
 import raw.runtime.truffle.runtime.record.RecordObject;
 
 import java.io.IOException;
@@ -63,7 +64,7 @@ public class RecordWriteCsvNode extends StatementNode {
             }
             doEndRow(generator);
         } catch (UnsupportedMessageException | InvalidArrayIndexException | UnknownIdentifierException e) {
-            throw new RawTruffleRuntimeException(e.getMessage(), this);
+            throw new RawTruffleRuntimeException("internal error", e, this);
         }
     }
 
@@ -71,8 +72,8 @@ public class RecordWriteCsvNode extends StatementNode {
     private void doStartRow(CsvGenerator gen) {
         try {
             gen.writeStartArray();
-        } catch (IOException ex) {
-            throw new RawTruffleRuntimeException(ex, this);
+        } catch (IOException e) {
+            throw new CsvWriterRawTruffleException(e.getMessage(), e, this);
         }
     }
 
@@ -80,8 +81,8 @@ public class RecordWriteCsvNode extends StatementNode {
     private void doEndRow(CsvGenerator gen) {
         try {
             gen.writeEndArray();
-        } catch (IOException ex) {
-            throw new RawTruffleRuntimeException(ex, this);
+        } catch (IOException e) {
+            throw new CsvWriterRawTruffleException(e.getMessage(), e, this);
         }
     }
 }

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/internal/ShortWriteCsvNode.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/internal/ShortWriteCsvNode.java
@@ -18,6 +18,7 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.NodeInfo;
 import raw.runtime.truffle.StatementNode;
 import raw.runtime.truffle.runtime.exceptions.RawTruffleRuntimeException;
+import raw.runtime.truffle.runtime.exceptions.csv.CsvWriterRawTruffleException;
 
 import java.io.IOException;
 
@@ -37,7 +38,7 @@ public class ShortWriteCsvNode extends StatementNode {
         try {
             gen.writeNumber(value);
         } catch (IOException e) {
-            throw new RawTruffleRuntimeException(e.getMessage());
+            throw new CsvWriterRawTruffleException(e.getMessage(), e, this);
         }
     }
 }

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/internal/StringWriteCsvNode.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/internal/StringWriteCsvNode.java
@@ -18,6 +18,7 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.NodeInfo;
 import raw.runtime.truffle.StatementNode;
 import raw.runtime.truffle.runtime.exceptions.RawTruffleRuntimeException;
+import raw.runtime.truffle.runtime.exceptions.csv.CsvWriterRawTruffleException;
 
 import java.io.IOException;
 
@@ -37,7 +38,7 @@ public class StringWriteCsvNode extends StatementNode {
         try {
             gen.writeString(value);
         } catch (IOException e) {
-            throw new RawTruffleRuntimeException(e.getMessage());
+            throw new CsvWriterRawTruffleException(e.getMessage(), e, this);
         }
     }
 }

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/internal/TimeWriteCsvNode.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/internal/TimeWriteCsvNode.java
@@ -18,6 +18,7 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.NodeInfo;
 import raw.runtime.truffle.StatementNode;
 import raw.runtime.truffle.runtime.exceptions.RawTruffleRuntimeException;
+import raw.runtime.truffle.runtime.exceptions.csv.CsvWriterRawTruffleException;
 import raw.runtime.truffle.runtime.primitives.TimeObject;
 
 import java.io.IOException;
@@ -41,7 +42,7 @@ public class TimeWriteCsvNode extends StatementNode {
         try {
             gen.writeString(formatter.format(value.getTime()));
         } catch (IOException e) {
-            throw new RawTruffleRuntimeException(e.getMessage());
+            throw new CsvWriterRawTruffleException(e.getMessage(), e, this);
         }
     }
 }

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/internal/TimestampWriteCsvNode.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/internal/TimestampWriteCsvNode.java
@@ -18,6 +18,7 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.NodeInfo;
 import raw.runtime.truffle.StatementNode;
 import raw.runtime.truffle.runtime.exceptions.RawTruffleRuntimeException;
+import raw.runtime.truffle.runtime.exceptions.csv.CsvWriterRawTruffleException;
 import raw.runtime.truffle.runtime.primitives.TimestampObject;
 
 import java.io.IOException;
@@ -41,7 +42,7 @@ public class TimestampWriteCsvNode extends StatementNode {
         try {
             gen.writeString(formatter.format(value.getTimestamp()));
         } catch (IOException e) {
-            throw new RawTruffleRuntimeException(e.getMessage());
+            throw new CsvWriterRawTruffleException(e.getMessage(), e, this);
         }
     }
 }

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/internal/TryableWriteCsvNode.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/internal/TryableWriteCsvNode.java
@@ -20,6 +20,7 @@ import com.oracle.truffle.api.nodes.NodeInfo;
 import raw.runtime.truffle.StatementNode;
 import raw.runtime.truffle.ast.ProgramStatementNode;
 import raw.runtime.truffle.runtime.exceptions.RawTruffleRuntimeException;
+import raw.runtime.truffle.runtime.exceptions.csv.CsvWriterRawTruffleException;
 import raw.runtime.truffle.runtime.tryable.TryableLibrary;
 
 import java.io.IOException;
@@ -54,7 +55,7 @@ public class TryableWriteCsvNode extends StatementNode {
         try {
             gen.writeString(message);
         } catch (IOException e) {
-            throw new RawTruffleRuntimeException(e.getMessage());
+            throw new CsvWriterRawTruffleException(e.getMessage(), e, this);
         }
     }
 }

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/runtime/exceptions/csv/CsvWriterRawTruffleException.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/runtime/exceptions/csv/CsvWriterRawTruffleException.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 RAW Labs S.A.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0, included in the file
+ * licenses/APL.txt.
+ */
+
+package raw.runtime.truffle.runtime.exceptions.csv;
+
+import com.oracle.truffle.api.nodes.Node;
+import raw.runtime.truffle.runtime.exceptions.RawTruffleRuntimeException;
+
+public class CsvWriterRawTruffleException extends RawTruffleRuntimeException {
+  public CsvWriterRawTruffleException(String message, Throwable cause, Node location) {
+    super("failed to write CSV: " + message, cause, location);
+  }
+}


### PR DESCRIPTION
This changeset defines a specific `CsvWriterRawTruffleException` for CSV writing, to be in line with other writers. Before merging make sure all these writer exceptions follow the same scheme (see the PR comment).