### PR TITLE
fix(ci): fix filename for the ci workflow trigger

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ on:
       - raw-*/**
       - build.sbt
       - project/**
-      - .github/workflows/CI.yaml
+      - .github/workflows/ci.yaml
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Previous trigger was for `CI.yaml` instead of the existing `ci.yaml`