### PR TITLE
RD-8998: Support for binary items in JSON and CSV

### DIFF
--- a/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/builtin/TruffleCsvPackage.scala
+++ b/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/builtin/TruffleCsvPackage.scala
@@ -16,6 +16,7 @@ import com.oracle.truffle.api.frame.FrameDescriptor
 import raw.compiler.base.source.Type
 import raw.compiler.rql2.builtin.{CsvParseEntry, CsvReadEntry}
 import raw.compiler.rql2.source.{
+  Rql2BinaryType,
   Rql2BoolType,
   Rql2ByteType,
   Rql2DateType,
@@ -66,6 +67,7 @@ import raw.runtime.truffle.ast.csv.reader.parser.{
   TryableParseCsvNode
 }
 import raw.runtime.truffle.ast.csv.writer.internal.{
+  BinaryWriteCsvNode,
   BoolWriteCsvNode,
   ByteWriteCsvNode,
   DateWriteCsvNode,
@@ -278,6 +280,7 @@ object CsvWriter {
           case _: Rql2DateType => new DateWriteCsvNode()
           case _: Rql2TimeType => new TimeWriteCsvNode()
           case _: Rql2TimestampType => new TimestampWriteCsvNode()
+          case _: Rql2BinaryType => new BinaryWriteCsvNode()
         }
     }
   }

--- a/raw-compiler-rql2-truffle/src/test/scala/raw/compiler/rql2/tests/output/TruffleOutputTest.scala
+++ b/raw-compiler-rql2-truffle/src/test/scala/raw/compiler/rql2/tests/output/TruffleOutputTest.scala
@@ -18,3 +18,4 @@ import raw.testing.tags.TruffleTests
 @TruffleTests class BinaryOutputTruffleTest extends TruffleCompilerTestContext with BinaryOutputTest
 // class TextOutputTruffleTest extends TruffleCompilerTestContext with TextOutputTest
 @TruffleTests class CsvOutputTruffleTest extends TruffleCompilerTestContext with CsvOutputTest
+@TruffleTests class JsonOutputTruffleTest extends TruffleCompilerTestContext with JsonOutputTest

--- a/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/CompilerTestContext.scala
+++ b/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/CompilerTestContext.scala
@@ -34,6 +34,7 @@ import java.nio.charset.{Charset, StandardCharsets}
 import java.nio.file.{Files, Path, StandardOpenOption}
 import java.util.concurrent.atomic.AtomicInteger
 import scala.collection.mutable
+import scala.io.Source
 
 trait CompilerTestContext
     extends RawTestSuite
@@ -515,6 +516,14 @@ trait CompilerTestContext
 
   def saveToInFormat(path: Path, format: String, executionLogger: ExecutionLogger = DebugExecutionLogger): SaveTo =
     new SaveTo(path, Map("output-format" -> format), executionLogger)
+
+  // a Matcher[Path] that compares the content of the file at the given path to the given string.
+  protected def contain(content: String) = be(content) compose { p: Path =>
+    val bufferedSource = Source.fromFile(p.toFile)
+    val fileContent = bufferedSource.mkString
+    bufferedSource.close()
+    fileContent
+  }
 
   /////////////////////////////////////////////////////////////////////////
   // Helper Functions

--- a/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/builtin/BinaryPackageTest.scala
+++ b/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/builtin/BinaryPackageTest.scala
@@ -22,14 +22,14 @@ trait BinaryPackageTest extends CompilerTestContext {
 
   // FIXME (msb): This should use cast to support string to binary and do .getBytes("utf-8")
 
-  val helloBase64 = Base64.getEncoder.encodeToString("Hello World".getBytes)
+  private val helloBase64 = Base64.getEncoder.encodeToString("Hello World".getBytes)
 
   test(s"""Binary.Base64(Binary.FromString("Hello World"))""") { it =>
     it should evaluateTo("""String.Base64("Hello World")""")
     it should evaluateTo(s""" "$helloBase64" """)
   }
 
-  val hello: Path = tempFile("Hello World")
+  private val hello: Path = tempFile("Hello World")
   test(s"""Binary.Base64(Binary.Read("file:$hello"))""") { it =>
     it should evaluateTo("""String.Base64("Hello World")""")
     it should evaluateTo(s""" "$helloBase64" """)

--- a/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/output/CsvOutputTest.scala
+++ b/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/output/CsvOutputTest.scala
@@ -14,6 +14,7 @@ package raw.compiler.rql2.tests.output
 
 import raw.compiler.rql2.tests.CompilerTestContext
 import raw.compiler.RQLInterpolator
+import raw.utils.RawUtils
 
 import java.nio.file.Files
 
@@ -30,22 +31,23 @@ trait CsvOutputTest extends CompilerTestContext {
     |{byteCol: Int.From("1"), shortCol:Int.From("10"), intCol: Int.From("100"), longCol: Int.From("1000"),
     | floatCol: Double.From("3.14"), doubleCol: Double.From("6.28"), decimalCol: Double.From("9.42"), boolCol: true,
     | dateCol: Date.Parse("12/25/2023", "M/d/yyyy"), timeCol: Time.Parse("01:02:03", "H:m:s"),
-    | timestampCol: Timestamp.Parse("12/25/2023 01:02:03", "M/d/yyyy H:m:s")},
+    | timestampCol: Timestamp.Parse("12/25/2023 01:02:03", "M/d/yyyy H:m:s"), binaryCol: Binary.FromString("Hello World!")},
     |{byteCol: Int.From("120"), shortCol:Int.From("2500"), intCol: Int.From("25000"), longCol: Int.From("250000"),
     | floatCol: Double.From("30.14"), doubleCol: Double.From("60.28"), decimalCol: Double.From("90.42"), boolCol: false,
     | dateCol: Date.Parse("2/5/2023", "M/d/yyyy"), timeCol: Time.Parse("11:12:13", "H:m:s"),
-    | timestampCol: Timestamp.Parse("2/5/2023 11:12:13", "M/d/yyyy H:m:s")}
+    | timestampCol: Timestamp.Parse("2/5/2023 11:12:13", "M/d/yyyy H:m:s"), binaryCol: Binary.FromString("Olala!")}
     |]""".stripMargin) { it =>
     val path = Files.createTempFile("", "")
     try {
       it should saveToInFormat(path, "csv")
-      path should contain
-      ("""byteCol,shortCol,intCol,longCol,floatCol,doubleCol,decimalCol,boolCol,dateCol,timeCol,timestampCol
-        |1,10,100,1000,3.14,6.28,9.42,true,2023-12-25,01:02:03,2023-12-25T01:02:03
-        |120,2500,25000,250000,30.14,60.28,90.42,false,2023-02-05,11:12:13,2023-02-05T11:12:13
-        |""".stripMargin)
+      path should contain(
+        """byteCol,shortCol,intCol,longCol,floatCol,doubleCol,decimalCol,boolCol,dateCol,timeCol,timestampCol,binaryCol
+          |1,10,100,1000,3.14,6.28,9.42,true,2023-12-25,01:02:03,2023-12-25T01:02:03,SGVsbG8gV29ybGQh
+          |120,2500,25000,250000,30.14,60.28,90.42,false,2023-02-05,11:12:13,2023-02-05T11:12:13,T2xhbGEh
+          |""".stripMargin
+      )
     } finally {
-      Files.deleteIfExists(path)
+      RawUtils.deleteTestPath(path)
     }
   }
 
@@ -53,13 +55,14 @@ trait CsvOutputTest extends CompilerTestContext {
     val path = Files.createTempFile("", "")
     try {
       it should saveToInFormat(path, "csv")
-      path should contain
-      ("""byteCol,shortCol,intCol,longCol,floatCol,doubleCol,decimalCol,boolCol,dateCol,timeCol,timestampCol
-        |1,10,100,1000,3.14,6.28,9.42,true,2023-12-25,01:02:03,2023-12-25T01:02:03
-        |120,2500,25000,250000,30.14,60.28,90.42,false,2023-02-05,11:12:13,2023-02-05T11:12:13
-        |""".stripMargin)
+      path should contain(
+        """byteCol,shortCol,intCol,longCol,floatCol,doubleCol,decimalCol,boolCol,dateCol,timeCol,timestampCol
+          |1,10,100,1000,3.14,6.28,9.42,true,2023-12-25,01:02:03,2023-12-25T01:02:03
+          |120,2500,25000,250000,30.14,60.28,90.42,false,2023-02-05,11:12:13,2023-02-05T11:12:13
+          |""".stripMargin
+      )
     } finally {
-      Files.deleteIfExists(path)
+      RawUtils.deleteTestPath(path)
     }
   }
 
@@ -81,13 +84,14 @@ trait CsvOutputTest extends CompilerTestContext {
     val path = Files.createTempFile("", "")
     try {
       it should saveToInFormat(path, "csv")
-      path should contain
-      ("""byteCol,shortCol,intCol,longCol,floatCol,doubleCol,decimalCol,boolCol,dateCol,timeCol,timestampCol
-        |1,10,100,1000,3.14,6.28,9.42,true,2023-12-25,01:02:03,2023-12-25T01:02:03
-        |120,2500,25000,250000,30.14,60.28,90.42,false,2023-02-05,11:12:13,2023-02-05T11:12:13
-        |""".stripMargin)
+      path should contain(
+        """byteCol,shortCol,intCol,longCol,floatCol,doubleCol,decimalCol,boolCol,dateCol,timeCol,timestampCol
+          |1,10,100,1000,3.14,6.28,9.42,true,2023-12-25,01:02:03,2023-12-25T01:02:03
+          |120,2500,25000,250000,30.14,60.28,90.42,false,2023-02-05,11:12:13,2023-02-05T11:12:13
+          |""".stripMargin
+      )
     } finally {
-      Files.deleteIfExists(path)
+      RawUtils.deleteTestPath(path)
     }
   }
 
@@ -109,13 +113,25 @@ trait CsvOutputTest extends CompilerTestContext {
     val path = Files.createTempFile("", "")
     try {
       it should saveToInFormat(path, "csv")
-      path should contain
-      ("""cannot cast 'byteCol' to byte,cannot cast 'shortCol' to short,cannot cast 'intCol' to int,cannot cast 'longCol' to long,cannot cast 'floatCol' to float,cannot cast 'doubleCol' to double,cannot cast 'decimalCol' to decimal,cannot cast 'boolCol' to bool,cannot cast 'dateCol' to date,cannot cast 'timeCol' to time,cannot cast 'timestampCol' to timestamp
-        |1,10,100,1000,3.14,6.28,9.42,true,2023-12-25,01:02:03,2023-12-25T01:02:03
-        |120,2500,25000,250000,30.14,60.28,90.42,false,2023-02-05,11:12:13,2023-02-05T11:12:13
-        |""".stripMargin)
+      if (language == "rql2-truffle") {
+        path should contain(
+          rql"""byteCol,shortCol,intCol,longCol,floatCol,doubleCol,decimalCol,boolCol,dateCol,timeCol,timestampCol
+            |"failed to parse CSV (url: $csvWithAllTypes: line 1, col 1), cannot parse 'byteCol' as a byte","failed to parse CSV (url: $csvWithAllTypes: line 1, col 9), cannot parse 'shortCol' as a short","failed to parse CSV (url: $csvWithAllTypes: line 1, col 18), cannot parse 'intCol' as an int","failed to parse CSV (url: $csvWithAllTypes: line 1, col 25), cannot parse 'longCol' as a long","failed to parse CSV (url: $csvWithAllTypes: line 1, col 33), cannot parse 'floatCol' as a float","failed to parse CSV (url: $csvWithAllTypes: line 1, col 42), cannot parse 'doubleCol' as a double","failed to parse CSV (url: $csvWithAllTypes: line 1, col 52), cannot parse 'decimalCol' as a decimal","failed to parse CSV (url: $csvWithAllTypes: line 1, col 63), cannot parse 'boolCol' as a bool","failed to parse CSV (url: $csvWithAllTypes: line 1, col 71), string 'dateCol' does not match date template 'yyyy-M-d'","failed to parse CSV (url: $csvWithAllTypes: line 1, col 79), string 'timeCol' does not match time template 'HH:mm[:ss[.SSS]]'","failed to parse CSV (url: $csvWithAllTypes: line 1, col 87), string 'timestampCol' does not match timestamp template 'HH:mm[:ss[.SSS]]'"
+            |1,10,100,1000,3.14,6.28,9.42,true,2023-12-25,01:02:03,2023-12-25T01:02:03
+            |120,2500,25000,250000,30.14,60.28,90.42,false,2023-02-05,11:12:13,2023-02-05T11:12:13
+            |""".stripMargin
+        )
+      } else {
+        path should contain(
+          """byteCol,shortCol,intCol,longCol,floatCol,doubleCol,decimalCol,boolCol,dateCol,timeCol,timestampCol
+            |"failed to parse CSV (line 1, col 1), cannot cast 'byteCol' to byte","failed to parse CSV (line 1, col 2), cannot cast 'shortCol' to short","failed to parse CSV (line 1, col 3), cannot cast 'intCol' to int","failed to parse CSV (line 1, col 4), cannot cast 'longCol' to long","failed to parse CSV (line 1, col 5), cannot cast 'floatCol' to float","failed to parse CSV (line 1, col 6), cannot cast 'doubleCol' to double","failed to parse CSV (line 1, col 7), Character d is neither a decimal digit number, decimal point, nor \"e\" notation exponential mark.","failed to parse CSV (line 1, col 8), cannot cast 'boolCol' to boolean","failed to parse CSV (line 1, col 9), string 'dateCol' does not match date template 'yyyy-M-d'","failed to parse CSV (line 1, col 10), string 'timeCol' does not match time template 'HH:mm[:ss[.SSS]]'","failed to parse CSV (line 1, col 11), string 'timestampCol' does not match timestamp template 'yyyy-M-d['T'][ ]HH:mm[:ss[.SSS]]'"
+            |1,10,100,1000,3.14,6.28,9.42,true,2023-12-25,01:02:03,2023-12-25T01:02:03
+            |120,2500,25000,250000,30.14,60.28,90.42,false,2023-02-05,11:12:13,2023-02-05T11:12:13
+            |""".stripMargin
+        )
+      }
     } finally {
-      Files.deleteIfExists(path)
+      RawUtils.deleteTestPath(path)
     }
   }
 }

--- a/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/output/JsonOutputTest.scala
+++ b/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/output/JsonOutputTest.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 RAW Labs S.A.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0, included in the file
+ * licenses/APL.txt.
+ */
+
+package raw.compiler.rql2.tests.output
+
+import raw.compiler.rql2.tests.CompilerTestContext
+import raw.utils.RawUtils
+
+import java.nio.file.{Files, Path}
+
+trait JsonOutputTest extends CompilerTestContext {
+
+  option("output-format", "json")
+
+  test("""[
+    |{byteCol: Int.From("1"), shortCol:Int.From("10"), intCol: Int.From("100"), longCol: Int.From("1000"),
+    | floatCol: Double.From("3.14"), doubleCol: Double.From("6.28"), decimalCol: Double.From("9.42"), boolCol: true,
+    | dateCol: Date.Parse("12/25/2023", "M/d/yyyy"), timeCol: Time.Parse("01:02:03", "H:m:s"),
+    | timestampCol: Timestamp.Parse("12/25/2023 01:02:03", "M/d/yyyy H:m:s"), binaryCol: Binary.FromString("Hello World!")},
+    |{byteCol: Int.From("120"), shortCol:Int.From("2500"), intCol: Int.From("25000"), longCol: Int.From("250000"),
+    | floatCol: Double.From("30.14"), doubleCol: Double.From("60.28"), decimalCol: Double.From("90.42"), boolCol: false,
+    | dateCol: Date.Parse("2/5/2023", "M/d/yyyy"), timeCol: Time.Parse("11:12:13", "H:m:s"),
+    | timestampCol: Timestamp.Parse("2/5/2023 11:12:13", "M/d/yyyy H:m:s"), binaryCol: Binary.FromString("Olala!")}
+    |]""".stripMargin) { it =>
+    val path: Path = Files.createTempFile("", "")
+    try {
+      it should saveToInFormat(path, "json")
+      if (language == "rql2-truffle") {
+        path should contain(
+          """[{"byteCol":1,"shortCol":10,"intCol":100,"longCol":1000,"floatCol":3.14,"doubleCol":6.28,"decimalCol":9.42,"boolCol":true,""" +
+            """"dateCol":"2023-12-25","timeCol":"01:02:03","timestampCol":"2023-12-25T01:02:03","binaryCol":"SGVsbG8gV29ybGQh"},""" +
+            """{"byteCol":120,"shortCol":2500,"intCol":25000,"longCol":250000,"floatCol":30.14,"doubleCol":60.28,"decimalCol":90.42,"boolCol":false,""" +
+            """"dateCol":"2023-02-05","timeCol":"11:12:13","timestampCol":"2023-02-05T11:12:13","binaryCol":"T2xhbGEh"}]""".stripMargin
+        )
+      } else {
+        // scala adds .SSS to the time and timestamp columns (even if no milliseconds are present in the value).
+        path should contain(
+          """[{"byteCol":1,"shortCol":10,"intCol":100,"longCol":1000,"floatCol":3.14,"doubleCol":6.28,"decimalCol":9.42,"boolCol":true,""" +
+            """"dateCol":"2023-12-25","timeCol":"01:02:03.000","timestampCol":"2023-12-25T01:02:03.000","binaryCol":"SGVsbG8gV29ybGQh"},""" +
+            """{"byteCol":120,"shortCol":2500,"intCol":25000,"longCol":250000,"floatCol":30.14,"doubleCol":60.28,"decimalCol":90.42,"boolCol":false,""" +
+            """"dateCol":"2023-02-05","timeCol":"11:12:13.000","timestampCol":"2023-02-05T11:12:13.000","binaryCol":"T2xhbGEh"}]""".stripMargin
+        )
+      }
+    } finally {
+      RawUtils.deleteTestPath(path)
+    }
+  }
+
+}

--- a/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/regressions/RD7974Test.scala
+++ b/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/regressions/RD7974Test.scala
@@ -16,8 +16,7 @@ import org.scalatest.BeforeAndAfterEach
 import raw.compiler.rql2.tests.CompilerTestContext
 import raw.utils.RawUtils
 
-import java.nio.file.{Files, Path}
-import scala.io.Source
+import java.nio.file.Files
 
 trait RD7974Test extends CompilerTestContext with BeforeAndAfterEach {
 
@@ -26,13 +25,6 @@ trait RD7974Test extends CompilerTestContext with BeforeAndAfterEach {
   override def afterEach(): Unit = {
     super.afterEach()
     RawUtils.deleteTestPath(tmpFile)
-  }
-
-  private def contain(content: String) = be(content) compose { p: Path =>
-    val bufferedSource = Source.fromFile(p.toFile)
-    val fileContent = bufferedSource.mkString
-    bufferedSource.close()
-    fileContent
   }
 
   test("""let l = [3,2,1,0,-1,-2,-3]

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/internal/BinaryWriteCsvNode.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/internal/BinaryWriteCsvNode.java
@@ -17,6 +17,7 @@ import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.NodeInfo;
 import raw.runtime.truffle.StatementNode;
+import raw.runtime.truffle.runtime.exceptions.csv.CsvWriterRawTruffleException;
 
 import java.io.IOException;
 import java.util.Base64;
@@ -38,7 +39,7 @@ public class BinaryWriteCsvNode extends StatementNode {
       String result = Base64.getEncoder().encodeToString(value);
       gen.writeString(result);
     } catch (IOException e) {
-      throw new CsvWriterRawTruffleException(e.getMessage());
+      throw new CsvWriterRawTruffleException(e.getMessage(), e, this);
     }
   }
 }

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/internal/BinaryWriteCsvNode.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/internal/BinaryWriteCsvNode.java
@@ -17,38 +17,28 @@ import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.NodeInfo;
 import raw.runtime.truffle.StatementNode;
-import raw.runtime.truffle.runtime.exceptions.csv.CsvWriterRawTruffleException;
-import raw.runtime.truffle.runtime.primitives.TimeObject;
 
 import java.io.IOException;
-import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
+import java.util.Base64;
 
-@NodeInfo(shortName = "TimeWriteCsv")
-public class TimeWriteCsvNode extends StatementNode {
-
-  private final DateTimeFormatter formatter1 = DateTimeFormatter.ofPattern("HH:mm:ss");
-  private final DateTimeFormatter formatter2 = DateTimeFormatter.ofPattern("HH:mm:ss.SSS");
+@NodeInfo(shortName = "BinaryWriteCsv")
+public class BinaryWriteCsvNode extends StatementNode {
 
   @Override
   public void executeVoid(VirtualFrame frame) {
     Object[] args = frame.getArguments();
-    TimeObject value = (TimeObject) args[0];
+    byte[] value = (byte[]) args[0];
     CsvGenerator generator = (CsvGenerator) args[1];
     doWrite(value, generator);
   }
 
   @CompilerDirectives.TruffleBoundary
-  private void doWrite(TimeObject value, CsvGenerator gen) {
+  private void doWrite(byte[] value, CsvGenerator gen) {
     try {
-      LocalTime ts = value.getTime();
-      if (ts.getNano() != 0) {
-        gen.writeString(formatter2.format(ts));
-      } else {
-        gen.writeString(formatter1.format(ts));
-      }
+      String result = Base64.getEncoder().encodeToString(value);
+      gen.writeString(result);
     } catch (IOException e) {
-      throw new CsvWriterRawTruffleException(e.getMessage(), e, this);
+      throw new CsvWriterRawTruffleException(e.getMessage());
     }
   }
 }

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/internal/DateWriteCsvNode.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/internal/DateWriteCsvNode.java
@@ -40,6 +40,8 @@ public class DateWriteCsvNode extends StatementNode {
     @CompilerDirectives.TruffleBoundary
     private void doWrite(DateObject value, CsvGenerator gen) {
         try {
+            // .format throws DateTimeException if its internal StringBuilder throws an IOException.
+            // We consider it as an internal error and let it propagate.
             gen.writeString(formatter.format(value.getDate()));
         } catch (IOException e) {
             throw new CsvWriterRawTruffleException(e.getMessage(), e, this);

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/internal/TimestampWriteCsvNode.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/csv/writer/internal/TimestampWriteCsvNode.java
@@ -22,27 +22,34 @@ import raw.runtime.truffle.runtime.exceptions.csv.CsvWriterRawTruffleException;
 import raw.runtime.truffle.runtime.primitives.TimestampObject;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
 @NodeInfo(shortName = "TimestampWriteCsv")
 public class TimestampWriteCsvNode extends StatementNode {
 
-    private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+  private final DateTimeFormatter formatter1 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+  private final DateTimeFormatter formatter2 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS");
 
-    @Override
-    public void executeVoid(VirtualFrame frame) {
-        Object[] args = frame.getArguments();
-        TimestampObject value = (TimestampObject) args[0];
-        CsvGenerator generator = (CsvGenerator) args[1];
-        doWrite(value, generator);
-    }
+  @Override
+  public void executeVoid(VirtualFrame frame) {
+    Object[] args = frame.getArguments();
+    TimestampObject value = (TimestampObject) args[0];
+    CsvGenerator generator = (CsvGenerator) args[1];
+    doWrite(value, generator);
+  }
 
-    @CompilerDirectives.TruffleBoundary
-    private void doWrite(TimestampObject value, CsvGenerator gen) {
-        try {
-            gen.writeString(formatter.format(value.getTimestamp()));
-        } catch (IOException e) {
-            throw new CsvWriterRawTruffleException(e.getMessage(), e, this);
-        }
+  @CompilerDirectives.TruffleBoundary
+  private void doWrite(TimestampObject value, CsvGenerator gen) {
+    try {
+      LocalDateTime ts = value.getTimestamp();
+      if (ts.getNano() != 0) {
+        gen.writeString(formatter2.format(ts));
+      } else {
+        gen.writeString(formatter1.format(ts));
+      }
+    } catch (IOException e) {
+      throw new CsvWriterRawTruffleException(e.getMessage(), e, this);
     }
+  }
 }

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/json/writer/internal/TimeWriteJsonNode.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/json/writer/internal/TimeWriteJsonNode.java
@@ -21,21 +21,31 @@ import raw.runtime.truffle.runtime.exceptions.json.JsonWriterRawTruffleException
 import raw.runtime.truffle.runtime.primitives.TimeObject;
 
 import java.io.IOException;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 
 @NodeInfo(shortName = "TimeWriteJson")
 public class TimeWriteJsonNode extends StatementNode {
 
-    public void executeVoid(VirtualFrame frame) {
-        Object[] args = frame.getArguments();
-        this.doWrite((TimeObject) args[0], (JsonGenerator) args[1]);
-    }
+  private final DateTimeFormatter formatter1 = DateTimeFormatter.ofPattern("HH:mm:ss");
+  private final DateTimeFormatter formatter2 = DateTimeFormatter.ofPattern("HH:mm:ss.SSS");
 
-    @CompilerDirectives.TruffleBoundary
-    private void doWrite(TimeObject value, JsonGenerator gen) {
-        try {
-            gen.writeString(value.getTime().toString());
-        } catch (IOException e) {
-            throw new JsonWriterRawTruffleException(e.getMessage(), this);
-        }
+  public void executeVoid(VirtualFrame frame) {
+    Object[] args = frame.getArguments();
+    this.doWrite((TimeObject) args[0], (JsonGenerator) args[1]);
+  }
+
+  @CompilerDirectives.TruffleBoundary
+  private void doWrite(TimeObject value, JsonGenerator gen) {
+    try {
+      LocalTime ts = value.getTime();
+      if (ts.getNano() != 0) {
+        gen.writeString(formatter2.format(ts));
+      } else {
+        gen.writeString(formatter1.format(ts));
+      }
+    } catch (IOException e) {
+      throw new JsonWriterRawTruffleException(e.getMessage(), this);
     }
+  }
 }

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/json/writer/internal/TimestampWriteJsonNode.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/json/writer/internal/TimestampWriteJsonNode.java
@@ -27,8 +27,9 @@ import java.time.format.DateTimeFormatter;
 @NodeInfo(shortName = "TimestampWriteJson")
 public class TimestampWriteJsonNode extends StatementNode {
 
-    private final DateTimeFormatter formatter1 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
-    private final DateTimeFormatter formatter2 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS");
+    // two different formatters, depending on whether there are milliseconds or not.
+    private final DateTimeFormatter fmtWithoutMS = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+    private final DateTimeFormatter fmtWithMS = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS");
 
     public void executeVoid(VirtualFrame frame) {
         Object[] args = frame.getArguments();
@@ -39,10 +40,12 @@ public class TimestampWriteJsonNode extends StatementNode {
     private void doWrite(TimestampObject value, JsonGenerator gen) {
         try {
             LocalDateTime ts = value.getTimestamp();
+            // .format throws DateTimeException if its internal StringBuilder throws an IOException.
+            // We consider it as an internal error and let it propagate.
             if (ts.getNano() != 0) {
-                gen.writeString(formatter2.format(ts));
+                gen.writeString(fmtWithMS.format(ts));
             } else {
-                gen.writeString(formatter1.format(ts));
+                gen.writeString(fmtWithoutMS.format(ts));
             }
         } catch (IOException e) {
             throw new JsonWriterRawTruffleException(e.getMessage(), this);

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/json/writer/internal/TimestampWriteJsonNode.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/json/writer/internal/TimestampWriteJsonNode.java
@@ -21,22 +21,29 @@ import raw.runtime.truffle.runtime.exceptions.json.JsonWriterRawTruffleException
 import raw.runtime.truffle.runtime.primitives.TimestampObject;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
 @NodeInfo(shortName = "TimestampWriteJson")
 public class TimestampWriteJsonNode extends StatementNode {
+
+    private final DateTimeFormatter formatter1 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+    private final DateTimeFormatter formatter2 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS");
 
     public void executeVoid(VirtualFrame frame) {
         Object[] args = frame.getArguments();
         this.doWrite((TimestampObject) args[0], (JsonGenerator) args[1]);
     }
 
-    private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS");
-
     @CompilerDirectives.TruffleBoundary
     private void doWrite(TimestampObject value, JsonGenerator gen) {
         try {
-            gen.writeString(formatter.format(value.getTimestamp()));
+            LocalDateTime ts = value.getTimestamp();
+            if (ts.getNano() != 0) {
+                gen.writeString(formatter2.format(ts));
+            } else {
+                gen.writeString(formatter1.format(ts));
+            }
         } catch (IOException e) {
             throw new JsonWriterRawTruffleException(e.getMessage(), this);
         }


### PR DESCRIPTION
Both JSON and CSV are expected to support binary fields/columns, by turning them into their base64-encoded string.

I've edited existing tests to add a binary value to the output data and checked it's rendered as the base64-encoded string.

The CSV test has some more changes because it was using the wrong ScalaTest predicate.