### PR TITLE
chore: skip publish raw-cli

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -512,6 +512,7 @@ lazy val rawCli = (project in file("raw-cli"))
   )
   .settings(
     buildSettings,
+    publish / skip := false,
     libraryDependencies ++= jline,
     assembly / mainClass := Some("raw.cli.RawCli"),
     assembly / assemblyMergeStrategy := {

--- a/build.sbt
+++ b/build.sbt
@@ -512,7 +512,7 @@ lazy val rawCli = (project in file("raw-cli"))
   )
   .settings(
     buildSettings,
-    publish / skip := false,
+    publish / skip := true,
     libraryDependencies ++= jline,
     assembly / mainClass := Some("raw.cli.RawCli"),
     assembly / assemblyMergeStrategy := {


### PR DESCRIPTION
We don't want to publish the `raw-cli` api code. We are going to publish a fat JAR in a near future, making use [buildSnapi](https://github.com/raw-labs/snapi/blob/831e9b0fbfd8bb4bb292755813bf7ca82bb42e74/build.sbt#L537C1-L556) task