### PR TITLE
RD-9182 migrate from jjwt-jackson to jwt-core

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -344,7 +344,7 @@ lazy val rawSourcesHttp = (project in file("raw-sources-http"))
   .dependsOn(rawSourcesApi % "compile->compile;test->test")
   .settings(
     strictBuildExceptDeprecationsSettings,
-    libraryDependencies ++= Seq(jwtApi, jwtImpl, jwtJackson)
+    libraryDependencies ++= Seq(jwtApi, jwtImpl, jwtCore)
   )
 
 lazy val rawSourcesPgsql = (project in file("raw-sources-pgsql"))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -104,7 +104,7 @@ object Dependencies {
 
   val jwtImpl = "io.jsonwebtoken" % "jjwt-impl" % "0.11.5"
 
-  val jwtJackson = "io.jsonwebtoken" % "jjwt-jackson" % "0.11.5"
+  val jwtCore = "com.github.jwt-scala" %% "jwt-core" % "9.4.0"
 
   val jline = Seq(
     "org.jline" % "jline-terminal" % "3.23.0",


### PR DESCRIPTION
The current jjwt-jackson is causing transitive dep vuln. there is no new version since april 2022.
We decide here to use `jwt-core` from [github.com/jwt-scala](https://github.com/jwt-scala) instead.