### PR TITLE
RD-9224: support for top level methods

### DIFF
--- a/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/Rql2TruffleCompiler.scala
+++ b/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/Rql2TruffleCompiler.scala
@@ -348,6 +348,7 @@ class TruffleEmitterImpl(tree: Tree)(implicit programContext: ProgramContext)
         case _: Rql2ListType => getFrameDescriptorBuilder.addSlot(FrameSlotKind.Object, getIdnName(entity), null)
         case _: FunType => getFrameDescriptorBuilder.addSlot(FrameSlotKind.Object, getIdnName(entity), null)
         case _: Rql2RecordType => getFrameDescriptorBuilder.addSlot(FrameSlotKind.Object, getIdnName(entity), null)
+        case _: Rql2LocationType => getFrameDescriptorBuilder.addSlot(FrameSlotKind.Object, getIdnName(entity), null)
       }
       addSlot(entity, slot)
       WriteLocalVariableNodeGen.create(recurseExp(e), slot, rql2Type)

--- a/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/Rql2TruffleCompiler.scala
+++ b/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/Rql2TruffleCompiler.scala
@@ -218,12 +218,16 @@ class Rql2TruffleCompiler(implicit compilerContext: CompilerContext)
           )
         )
       case "binary" =>
-        val writer = TruffleBinaryWriter(tree.analyzer.tipe(me.get).asInstanceOf[Rql2BinaryType])
-        new ProgramStatementNode(
-          RawLanguage.getCurrentContext.getLanguage,
-          frameDescriptor,
-          new BinaryWriterNode(bodyExpNode, writer)
-        )
+        tree.analyzer.tipe(me.get) match {
+          case binary: Rql2BinaryType => // nullable or tryable is OK
+            val writer = TruffleBinaryWriter(binary)
+            new ProgramStatementNode(
+              RawLanguage.getCurrentContext.getLanguage,
+              frameDescriptor,
+              new BinaryWriterNode(bodyExpNode, writer)
+            )
+          case _ => throw new CompilerException("unsupported type")
+        }
       case null | "" => new ProgramExpressionNode(
           RawLanguage.getCurrentContext.getLanguage,
           frameDescriptor,

--- a/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/Rql2TruffleCompiler.scala
+++ b/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/Rql2TruffleCompiler.scala
@@ -217,8 +217,7 @@ class Rql2TruffleCompiler(implicit compilerContext: CompilerContext)
             JsonRecurse.recurseJsonWriter(tree.analyzer.tipe(me.get).asInstanceOf[Rql2TypeWithProperties])
           )
         )
-      case "binary" =>
-        tree.analyzer.tipe(me.get) match {
+      case "binary" => tree.analyzer.tipe(me.get) match {
           case binary: Rql2BinaryType => // nullable or tryable is OK
             val writer = TruffleBinaryWriter(binary)
             new ProgramStatementNode(

--- a/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/Rql2TruffleCompiler.scala
+++ b/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/Rql2TruffleCompiler.scala
@@ -168,7 +168,7 @@ class Rql2TruffleCompiler(implicit compilerContext: CompilerContext)
     val emitter = new TruffleEmitterImpl(tree)(programContext.asInstanceOf[ProgramContext])
 
     val Rql2Program(methods, me) = tree.root
-    assert(methods.isEmpty)
+    methods.foreach(emitter.emitMethod)
     assert(me.isDefined)
     val bodyExp = me.get
 
@@ -292,6 +292,11 @@ class TruffleEmitterImpl(tree: Tree)(implicit programContext: ProgramContext)
     slotMapScope.head.put(entity, slot)
   }
 
+  def emitMethod(m: Rql2Method): Unit = {
+    val funcName = getFuncIdn(analyzer.entity(m.i))
+    recurseFunProto(funcName, m.p)
+  }
+
   private def findSlot(entity: Entity): SlotLocation = {
     var depth = 0
     var curSlot = slotMapScope(depth)
@@ -324,12 +329,9 @@ class TruffleEmitterImpl(tree: Tree)(implicit programContext: ProgramContext)
       val entity = analyzer.entity(i)
       val rql2Type = tipe(e).asInstanceOf[Rql2Type]
 
-      // (az) this is a temporary solution for (RD-8995)
-      if (rql2Type.isInstanceOf[ExpType]) {
-        return recurseExp(e)
-      }
       val slot = rql2Type match {
         case _: Rql2UndefinedType => getFrameDescriptorBuilder.addSlot(FrameSlotKind.Object, getIdnName(entity), null)
+        case _: ExpType => getFrameDescriptorBuilder.addSlot(FrameSlotKind.Object, getIdnName(entity), null)
         case _: Rql2ByteType => getFrameDescriptorBuilder.addSlot(FrameSlotKind.Byte, getIdnName(entity), null)
         case _: Rql2ShortType => getFrameDescriptorBuilder.addSlot(FrameSlotKind.Int, getIdnName(entity), null)
         case _: Rql2IntType => getFrameDescriptorBuilder.addSlot(FrameSlotKind.Int, getIdnName(entity), null)
@@ -441,6 +443,11 @@ class TruffleEmitterImpl(tree: Tree)(implicit programContext: ProgramContext)
     case UnaryExp(Neg(), e) => NegNodeGen.create(recurseExp(e))
     case UnaryExp(Not(), e) => NotNodeGen.create(recurseExp(e))
     case IdnExp(idn) => analyzer.entity(idn) match {
+        case b: MethodEntity =>
+          val funcName = getFuncIdn(b)
+          val registry = RawLanguage.getCurrentContext.getFunctionRegistry
+          val function = registry.getFunction(funcName)
+          new MethodRefNode(function)
         case b: LetBindEntity =>
           val SlotLocation(depth, slot) = findSlot(b)
           if (depth == 0) {

--- a/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/builtin/TruffleJsonPackage.scala
+++ b/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/builtin/TruffleJsonPackage.scala
@@ -65,9 +65,7 @@ class TruffleReadJsonEntry extends ReadJsonEntry with TruffleEntryExtension {
             .recurseJsonParser(t.asInstanceOf[Rql2TypeWithProperties], dateFormat, timeFormat, timestampFormat)
         )
         if (t.asInstanceOf[Rql2TypeWithProperties].props.contains(Rql2IsTryableTypeProperty())) {
-          new TryableTopLevelWrapper(
-            new ProgramExpressionNode(JsonRecurse.lang, JsonRecurse.frameDescriptor, parseNode)
-          )
+          new TryableTopLevelWrapper(parseNode)
         } else {
           parseNode
         }
@@ -99,9 +97,7 @@ class TruffleParseJsonEntry extends ParseJsonEntry with TruffleEntryExtension {
     )
 
     if (t.asInstanceOf[Rql2TypeWithProperties].props.contains(Rql2IsTryableTypeProperty())) {
-      new TryableTopLevelWrapper(
-        new ProgramExpressionNode(JsonRecurse.lang, JsonRecurse.frameDescriptor, parseNode)
-      )
+      new TryableTopLevelWrapper(parseNode)
     } else {
       parseNode
     }

--- a/raw-compiler-rql2-truffle/src/test/scala/raw/compiler/rql2/tests/regressions/TruffleRegressionTest.scala
+++ b/raw-compiler-rql2-truffle/src/test/scala/raw/compiler/rql2/tests/regressions/TruffleRegressionTest.scala
@@ -67,7 +67,8 @@ import raw.testing.tags.TruffleTests
 // XML
 // class RD5679TruffleTest extends TruffleCompilerTestContext with RD5679Test
 
-@TruffleTests class RD5775TruffleTest extends TruffleCompilerTestContext with RD5775Test
+// Runs weird queries that aren't supported by JSON (package entry extensions, functions, etc.)
+// @TruffleTests class RD5775TruffleTest extends TruffleCompilerTestContext with RD5775Test
 @TruffleTests class RD5851TruffleTest extends TruffleCompilerTestContext with RD5851Test
 
 @TruffleTests class RD5412TruffleTest extends TruffleCompilerTestContext with RD5412Test

--- a/raw-compiler-rql2-truffle/src/test/scala/raw/compiler/rql2/tests/regressions/TruffleRegressionTest.scala
+++ b/raw-compiler-rql2-truffle/src/test/scala/raw/compiler/rql2/tests/regressions/TruffleRegressionTest.scala
@@ -24,8 +24,8 @@ import raw.testing.tags.TruffleTests
 // RD-9078
 // class RD5884TruffleTest extends TruffleCompilerTestContext with RD5884Test
 @TruffleTests class RD8266TruffleTest extends TruffleCompilerTestContext with RD8266Test
-// needs CSV, Xml, RD-9074
-// class RD5448TruffleTest extends TruffleCompilerTestContext with RD5448Test
+// needs Xml
+// @TruffleTests class RD5448TruffleTest extends TruffleCompilerTestContext with RD5448Test
 @TruffleTests class RD5238TruffleTest extends TruffleCompilerTestContext with RD5238Test
 @TruffleTests class RD3742TruffleTest extends TruffleCompilerTestContext with RD3742Test
 @TruffleTests class RD3784TruffleTest extends TruffleCompilerTestContext with RD3784Test
@@ -72,7 +72,7 @@ import raw.testing.tags.TruffleTests
 
 @TruffleTests class RD5412TruffleTest extends TruffleCompilerTestContext with RD5412Test
 
-// wrong type for 'binary' fails to be reported as expected
+// 'text' format not supported
 // @TruffleTests class RD5971TruffleTest extends TruffleCompilerTestContext with RD5971Test
 @TruffleTests class RD4445TruffleTest extends TruffleCompilerTestContext with RD4445Test
 
@@ -87,7 +87,7 @@ import raw.testing.tags.TruffleTests
 @TruffleTests class RD5786TruffleTest extends TruffleCompilerTestContext with RD5786Test
 
 // fails with an index error when reading a parameter (RD-9078 likely)
-//@TruffleTests class RD8015TruffleTest extends TruffleCompilerTestContext with RD8015Test
+// @TruffleTests class RD8015TruffleTest extends TruffleCompilerTestContext with RD8015Test
 @TruffleTests class RD5722TruffleTest extends TruffleCompilerTestContext with RD5722Test
 @TruffleTests class RD4741TruffleTest extends TruffleCompilerTestContext with RD4741Test
 @TruffleTests class RD5925TruffleTest extends TruffleCompilerTestContext with RD5925Test

--- a/raw-compiler-rql2-truffle/src/test/scala/raw/compiler/rql2/tests/regressions/TruffleRegressionTest.scala
+++ b/raw-compiler-rql2-truffle/src/test/scala/raw/compiler/rql2/tests/regressions/TruffleRegressionTest.scala
@@ -15,10 +15,8 @@ package raw.compiler.rql2.tests.regressions
 import raw.compiler.rql2.tests.TruffleCompilerTestContext
 import raw.testing.tags.TruffleTests
 
-// methods are not supported
-// class RD5631TruffleTest extends TruffleCompilerTestContext with RD5631Test
+@TruffleTests class RD5631TruffleTest extends TruffleCompilerTestContext with RD5631Test
 
-// HttpPackage
 @TruffleTests class RD5797TruffleTest extends TruffleCompilerTestContext with RD5797Test
 @TruffleTests class RD5779TruffleTest extends TruffleCompilerTestContext with RD5779Test
 @TruffleTests class RD5393TruffleTest extends TruffleCompilerTestContext with RD5393Test
@@ -49,12 +47,10 @@ import raw.testing.tags.TruffleTests
 // class RD5697TruffleTest extends TruffleCompilerTestContext with RD5697Test
 @TruffleTests class RD5644TruffleTest extends TruffleCompilerTestContext with RD5644Test
 
-// methods not supported
-// class RD8993TruffleTest extends TruffleCompilerTestContext with RD8993Test
+@TruffleTests class RD8993TruffleTest extends TruffleCompilerTestContext with RD8993Test
 @TruffleTests class RD4529TruffleTest extends TruffleCompilerTestContext with RD4529Test
 
-// methods not supported
-// class RD5502TruffleTest extends TruffleCompilerTestContext with RD5502Test
+@TruffleTests class RD5502TruffleTest extends TruffleCompilerTestContext with RD5502Test
 
 // XML
 // class RD5893TruffleTest extends TruffleCompilerTestContext with RD5893Test
@@ -71,31 +67,27 @@ import raw.testing.tags.TruffleTests
 // XML
 // class RD5679TruffleTest extends TruffleCompilerTestContext with RD5679Test
 
-// Needs Http and other things
-// class RD5775TruffleTest extends TruffleCompilerTestContext with RD5775Test
+@TruffleTests class RD5775TruffleTest extends TruffleCompilerTestContext with RD5775Test
 @TruffleTests class RD5851TruffleTest extends TruffleCompilerTestContext with RD5851Test
 
-// List.Union (RD-9053), S3Package
-// class RD5412TruffleTest extends TruffleCompilerTestContext with RD5412Test
+@TruffleTests class RD5412TruffleTest extends TruffleCompilerTestContext with RD5412Test
 
-// Binary format
-// class RD5971TruffleTest extends TruffleCompilerTestContext with RD5971Test
+// wrong type for 'binary' fails to be reported as expected
+// @TruffleTests class RD5971TruffleTest extends TruffleCompilerTestContext with RD5971Test
 @TruffleTests class RD4445TruffleTest extends TruffleCompilerTestContext with RD4445Test
 
 // XML
 // class RD5968TruffleTest extends TruffleCompilerTestContext with RD5968Test
 
-// Collection.Union
-// class RD5691TruffleTest extends TruffleCompilerTestContext with RD5691Test
+@TruffleTests class RD5691TruffleTest extends TruffleCompilerTestContext with RD5691Test
 @TruffleTests class RD8935TruffleTest extends TruffleCompilerTestContext with RD8935Test
 @TruffleTests class RD7924TruffleTest extends TruffleCompilerTestContext with RD7924Test
 
-// methods not supported
-// class RD5488TruffleTest extends TruffleCompilerTestContext with RD5488Test
+@TruffleTests class RD5488TruffleTest extends TruffleCompilerTestContext with RD5488Test
 @TruffleTests class RD5786TruffleTest extends TruffleCompilerTestContext with RD5786Test
 
-// methods not supported
-// class RD8015TruffleTest extends TruffleCompilerTestContext with RD8015Test
+// fails with an index error when reading a parameter (RD-9078 likely)
+//@TruffleTests class RD8015TruffleTest extends TruffleCompilerTestContext with RD8015Test
 @TruffleTests class RD5722TruffleTest extends TruffleCompilerTestContext with RD5722Test
 @TruffleTests class RD4741TruffleTest extends TruffleCompilerTestContext with RD4741Test
 @TruffleTests class RD5925TruffleTest extends TruffleCompilerTestContext with RD5925Test

--- a/raw-compiler-rql2-truffle/src/test/scala/raw/compiler/rql2/tests/regressions/TruffleRegressionTest.scala
+++ b/raw-compiler-rql2-truffle/src/test/scala/raw/compiler/rql2/tests/regressions/TruffleRegressionTest.scala
@@ -114,3 +114,4 @@ import raw.testing.tags.TruffleTests
 // class RD5914TruffleTest extends TruffleCompilerTestContext with RD5914Test
 
 @TruffleTests class RD9137TruffleTest extends TruffleCompilerTestContext with RD9137Test
+@TruffleTests class RD9228TruffleTest extends TruffleCompilerTestContext with RD9228Test

--- a/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/regressions/RD9228Test.scala
+++ b/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/regressions/RD9228Test.scala
@@ -17,55 +17,48 @@ import raw.compiler.rql2.tests.CompilerTestContext
 trait RD9228Test extends CompilerTestContext {
 
   // pass a plain URL. It will be turned into a location, directly passed as a parameter.
-  test(
-    """
-      |Json.InferAndRead("https://raw-tutorial.s3.eu-west-1.amazonaws.com/trips.json")
-      |""".stripMargin)(_ should typeAs(
-    """collection(record(
-      |        reason: string,
-      |        origin: string,
-      |        destination: string,
-      |        dates: record(departure: date, arrival: date)
-      |    ))""".stripMargin))
+  test("""
+    |Json.InferAndRead("https://raw-tutorial.s3.eu-west-1.amazonaws.com/trips.json")
+    |""".stripMargin)(_ should typeAs("""collection(record(
+    |        reason: string,
+    |        origin: string,
+    |        destination: string,
+    |        dates: record(departure: date, arrival: date)
+    |    ))""".stripMargin))
 
   // pass a plain URL. It will be turned into a location, directly passed as a parameter.
-  test(
-    """
-      |Json.Read("https://raw-tutorial.s3.eu-west-1.amazonaws.com/trips.json", type list(record(
-      |        reason: string,
-      |        origin: string,
-      |        destination: string,
-      |        dates: record(departure: date, arrival: date)
-      |    )))
-      |""".stripMargin)(_ should run)
+  test("""
+    |Json.Read("https://raw-tutorial.s3.eu-west-1.amazonaws.com/trips.json", type list(record(
+    |        reason: string,
+    |        origin: string,
+    |        destination: string,
+    |        dates: record(departure: date, arrival: date)
+    |    )))
+    |""".stripMargin)(_ should run)
 
   // Declare the location as a variable. Json.Read has to resolve its value dynamically using a walk through frames.
   // Because we read a collection, no tryable handler is involved. No bug.
-  test(
-    """
-      |let location = Http.Get("https://raw-tutorial.s3.eu-west-1.amazonaws.com/trips.json")
-      |in Json.Read(location, type collection(record(
-      |        reason: string,
-      |        origin: string,
-      |        destination: string,
-      |        dates: record(departure: date, arrival: date)
-      |    )))
-      |""".stripMargin)(_ should run)
-
+  test("""
+    |let location = Http.Get("https://raw-tutorial.s3.eu-west-1.amazonaws.com/trips.json")
+    |in Json.Read(location, type collection(record(
+    |        reason: string,
+    |        origin: string,
+    |        destination: string,
+    |        dates: record(departure: date, arrival: date)
+    |    )))
+    |""".stripMargin)(_ should run)
 
   // Declare the location as a variable. Json.Read has to resolve its value dynamically using a walk through frames.
   // Because we read a tryable (list), the tryable handler is involved. It didn't expect the nested read to have a
   // free variable.
-  test(
-    """
-      |let location = Http.Get("https://raw-tutorial.s3.eu-west-1.amazonaws.com/trips.json")
-      |in Json.Read(location, type list(record(
-      |        reason: string,
-      |        origin: string,
-      |        destination: string,
-      |        dates: record(departure: date, arrival: date)
-      |    )))
-      |""".stripMargin)(_ should run)
-
+  test("""
+    |let location = Http.Get("https://raw-tutorial.s3.eu-west-1.amazonaws.com/trips.json")
+    |in Json.Read(location, type list(record(
+    |        reason: string,
+    |        origin: string,
+    |        destination: string,
+    |        dates: record(departure: date, arrival: date)
+    |    )))
+    |""".stripMargin)(_ should run)
 
 }

--- a/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/regressions/RD9228Test.scala
+++ b/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/regressions/RD9228Test.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 RAW Labs S.A.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0, included in the file
+ * licenses/APL.txt.
+ */
+
+package raw.compiler.rql2.tests.regressions
+
+import raw.compiler.rql2.tests.CompilerTestContext
+
+trait RD9228Test extends CompilerTestContext {
+
+  test(
+    """
+      |Json.InferAndRead("https://raw-tutorial.s3.eu-west-1.amazonaws.com/trips.json")
+      |""".stripMargin)(_ should typeAs(
+    """collection(record(
+      |        reason: string,
+      |        origin: string,
+      |        destination: string,
+      |        dates: record(departure: date, arrival: date)
+      |    ))""".stripMargin))
+
+  test(
+    """
+      |Json.Read("https://raw-tutorial.s3.eu-west-1.amazonaws.com/trips.json", type list(record(
+      |        reason: string,
+      |        origin: string,
+      |        destination: string,
+      |        dates: record(departure: date, arrival: date)
+      |    )))
+      |""".stripMargin)(_ should run)
+
+  test(
+    """
+      |let location = Http.Get("https://raw-tutorial.s3.eu-west-1.amazonaws.com/trips.json")
+      |in Json.Read(location, type collection(record(
+      |        reason: string,
+      |        origin: string,
+      |        destination: string,
+      |        dates: record(departure: date, arrival: date)
+      |    )))
+      |""".stripMargin)(_ should run)
+
+  test(
+    """
+      |let location = Http.Get("https://raw-tutorial.s3.eu-west-1.amazonaws.com/trips.json")
+      |in Json.Read(location, type list(record(
+      |        reason: string,
+      |        origin: string,
+      |        destination: string,
+      |        dates: record(departure: date, arrival: date)
+      |    )))
+      |""".stripMargin)(_ should run)
+
+
+}

--- a/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/regressions/RD9228Test.scala
+++ b/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/regressions/RD9228Test.scala
@@ -16,6 +16,7 @@ import raw.compiler.rql2.tests.CompilerTestContext
 
 trait RD9228Test extends CompilerTestContext {
 
+  // pass a plain URL. It will be turned into a location, directly passed as a parameter.
   test(
     """
       |Json.InferAndRead("https://raw-tutorial.s3.eu-west-1.amazonaws.com/trips.json")
@@ -27,6 +28,7 @@ trait RD9228Test extends CompilerTestContext {
       |        dates: record(departure: date, arrival: date)
       |    ))""".stripMargin))
 
+  // pass a plain URL. It will be turned into a location, directly passed as a parameter.
   test(
     """
       |Json.Read("https://raw-tutorial.s3.eu-west-1.amazonaws.com/trips.json", type list(record(
@@ -37,6 +39,8 @@ trait RD9228Test extends CompilerTestContext {
       |    )))
       |""".stripMargin)(_ should run)
 
+  // Declare the location as a variable. Json.Read has to resolve its value dynamically using a walk through frames.
+  // Because we read a collection, no tryable handler is involved. No bug.
   test(
     """
       |let location = Http.Get("https://raw-tutorial.s3.eu-west-1.amazonaws.com/trips.json")
@@ -48,6 +52,10 @@ trait RD9228Test extends CompilerTestContext {
       |    )))
       |""".stripMargin)(_ should run)
 
+
+  // Declare the location as a variable. Json.Read has to resolve its value dynamically using a walk through frames.
+  // Because we read a tryable (list), the tryable handler is involved. It didn't expect the nested read to have a
+  // free variable.
   test(
     """
       |let location = Http.Get("https://raw-tutorial.s3.eu-west-1.amazonaws.com/trips.json")

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/expressions/function/InvokeNode.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/expressions/function/InvokeNode.java
@@ -20,6 +20,7 @@ import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.NodeInfo;
 import raw.runtime.truffle.ExpressionNode;
 import raw.runtime.truffle.runtime.function.Closure;
+import raw.runtime.truffle.runtime.function.MethodRef;
 
 @NodeInfo(shortName = "invoke")
 public final class InvokeNode extends ExpressionNode {
@@ -39,13 +40,24 @@ public final class InvokeNode extends ExpressionNode {
     public Object executeGeneric(VirtualFrame frame) {
         CompilerAsserts.compilationConstant(argumentNodes.length);
 
-        Closure closure = (Closure) functionNode.executeGeneric(frame);
-
-        Object[] argumentValues = new Object[argumentNodes.length];
-        for (int i = 0; i < argumentNodes.length; i++) {
-            argumentValues[i] = argumentNodes[i].executeGeneric(frame);
+        Object executable = functionNode.executeGeneric(frame);
+        if (executable instanceof Closure) {
+            Object[] argumentValues = new Object[argumentNodes.length];
+            for (int i = 0; i < argumentNodes.length; i++) {
+                argumentValues[i] = argumentNodes[i].executeGeneric(frame);
+            }
+            Closure closure = (Closure) executable;
+            return closure.call(argumentValues);
+        } else {
+            Object[] argumentValues = new Object[argumentNodes.length+1];
+            argumentValues[0] = frame;
+            for (int i = 0; i < argumentNodes.length; i++) {
+                argumentValues[i + 1] = argumentNodes[i].executeGeneric(frame);
+            }
+            MethodRef ref = (MethodRef) executable;
+            return ref.call(argumentValues);
         }
-        return closure.call(argumentValues);
+
     }
 
     @Override

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/expressions/function/MethodRefNode.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/expressions/function/MethodRefNode.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 RAW Labs S.A.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0, included in the file
+ * licenses/APL.txt.
+ */
+
+package raw.runtime.truffle.ast.expressions.function;
+
+import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import raw.runtime.truffle.ExpressionNode;
+import raw.runtime.truffle.runtime.function.Closure;
+import raw.runtime.truffle.runtime.function.Function;
+import raw.runtime.truffle.runtime.function.MethodRef;
+
+public final class MethodRefNode extends ExpressionNode {
+
+    @CompilationFinal
+    private final Function function;
+
+    public MethodRefNode(Function f) {
+        this.function = f;
+    }
+
+    @Override
+    public Object executeGeneric(VirtualFrame virtualFrame) {
+        return new MethodRef(this.function, this);
+    }
+}

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/expressions/iterable/list/ListTakeNode.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/expressions/iterable/list/ListTakeNode.java
@@ -128,7 +128,7 @@ public abstract class ListTakeNode extends ExpressionNode {
         if (num >= innerList.length) {
             return (ObjectList) list;
         }
-        Object[] result = new String[(int) num];
+        Object[] result = new Object[(int) num];
         System.arraycopy(innerList, 0, result, 0, (int) num);
         return new ObjectList(result);
     }

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/json/reader/TryableTopLevelWrapper.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/json/reader/TryableTopLevelWrapper.java
@@ -16,9 +16,7 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.DirectCallNode;
 import com.oracle.truffle.api.nodes.NodeInfo;
 import raw.runtime.truffle.ExpressionNode;
-import raw.runtime.truffle.ast.ProgramExpressionNode;
 import raw.runtime.truffle.runtime.exceptions.RawTruffleRuntimeException;
-import raw.runtime.truffle.runtime.exceptions.json.JsonParserRawTruffleException;
 import raw.runtime.truffle.runtime.nullable_tryable.NullableTryableLibrary;
 import raw.runtime.truffle.runtime.nullable_tryable.RuntimeNullableTryableHandler;
 import raw.runtime.truffle.runtime.tryable.ErrorTryable;
@@ -29,7 +27,7 @@ import raw.runtime.truffle.runtime.tryable.TryableLibrary;
 public class TryableTopLevelWrapper extends ExpressionNode {
 
     @Child
-    private DirectCallNode childDirectCall;
+    private ExpressionNode reader;
     private final RuntimeNullableTryableHandler nullableTryableHandler = new RuntimeNullableTryableHandler();
     @Child
     private NullableTryableLibrary nullableTryable = NullableTryableLibrary.getFactory().create(nullableTryableHandler);
@@ -37,13 +35,13 @@ public class TryableTopLevelWrapper extends ExpressionNode {
     @Child
     private TryableLibrary tryables = TryableLibrary.getFactory().createDispatched(1);
 
-    public TryableTopLevelWrapper(ProgramExpressionNode childProgramStatementNode) {
-        this.childDirectCall = DirectCallNode.create(childProgramStatementNode.getCallTarget());
+    public TryableTopLevelWrapper(ExpressionNode reader) {
+        this.reader = reader;
     }
 
     public Object executeGeneric(VirtualFrame frame) {
         try {
-            Object result = childDirectCall.call();
+            Object result = reader.executeGeneric(frame);
             if (tryables.isTryable(result)) {
                 return result;
             }

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/runtime/function/MethodRef.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/runtime/function/MethodRef.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 RAW Labs S.A.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0, included in the file
+ * licenses/APL.txt.
+ */
+
+package raw.runtime.truffle.runtime.function;
+
+import com.oracle.truffle.api.frame.MaterializedFrame;
+import com.oracle.truffle.api.interop.ArityException;
+import com.oracle.truffle.api.interop.InteropLibrary;
+import com.oracle.truffle.api.interop.UnsupportedMessageException;
+import com.oracle.truffle.api.interop.UnsupportedTypeException;
+import com.oracle.truffle.api.nodes.Node;
+import raw.runtime.truffle.runtime.exceptions.RawTruffleInternalErrorException;
+
+public class MethodRef {
+    private final Function function;
+    private final InteropLibrary interop;
+    private final Node node;
+
+    public MethodRef(Function function, Node node) {
+        this.function = function;
+        this.node = node;
+        this.interop = InteropLibrary.getFactory().create(function);
+    }
+
+    public Object call(Object... arguments) {
+        try {
+            return interop.execute(function, arguments);
+        } catch (UnsupportedTypeException | ArityException | UnsupportedMessageException e) {
+            throw new RawTruffleInternalErrorException(e, node);
+        }
+    }
+}


### PR DESCRIPTION
This is a working version, although not sure of all details. I see it works.

I added the following steps:
* register methods using the existing `recurseFunProto`.
* added a `MethodRefNode` node to implement `IdnExp` when it points to a method (instead of using `ReadLocalVariable` and the like, I think those would't work. That node embeds a ref to the top-level function to be called. It's very similar to a `ClosureNode` except that it doesn't embed a materialized frame.
* `InvokeNode`: handle both objects `Closure` and `MethodRef` using `isInstanceOf`. I thought of defining a specific `MethodInvoke` node but when generating an `InvokeNode`, one doesn't know which kind of object will be passed as a parameter (e.g. `List.Transform` can receive a method or a closure).

I enabled a bunch of regression tests (see the code). By doing that I hit a couple of new bugs. See inline comments.