### PR TITLE
RD-9223 truffle-execution-load-test

### DIFF
--- a/raw-compiler-rql2-truffle/src/test/scala/raw/compiler/rql2/tests/benchmark/TruffleBenchmarkTest.scala
+++ b/raw-compiler-rql2-truffle/src/test/scala/raw/compiler/rql2/tests/benchmark/TruffleBenchmarkTest.scala
@@ -16,3 +16,5 @@ import raw.compiler.rql2.tests.TruffleCompilerTestContext
 import raw.testing.tags.TruffleTests
 
 @TruffleTests class BenchmarkTruffleTests extends TruffleCompilerTestContext with BenchmarkTests
+
+@TruffleTests class StressTruffleTests extends TruffleCompilerTestContext with StressTests

--- a/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/benchmark/StressTests.scala
+++ b/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/benchmark/StressTests.scala
@@ -1,0 +1,33 @@
+package raw.compiler.rql2.tests.benchmark
+
+import raw.compiler.rql2.tests.CompilerTestContext
+
+trait StressTests extends CompilerTestContext {
+
+  val shouldBeExecuted = false
+
+  val numberOfRuns = 10000
+
+  test("Testing code caches and memory leaks") { _ =>
+    assume(shouldBeExecuted, "This test is disabled by default")
+
+    fastExecute("""let a = "hello" in a """) // some random query
+    fastExecute("""let a = 2 + 2 in a """) // some random query
+    fastExecute("""let a = 2/2 in a """) // some random query
+
+    for (i <- 0 to numberOfRuns) {
+      fastExecute(
+        s"Collection.Filter(Int.Range(0,10,step=1), x -> x > 5)"
+      )
+      fastExecute(
+        s"Collection.Filter(Long.Range(0,10,step=2), x -> x == 5)"
+      )
+      logger.info("\n++++++++++ iteration: " + i)
+    }
+
+//    -XX: ReservedCodeCacheSize=15000k
+//    -XX :+ UseCodeCacheFlushing
+//    -XX :+ SegmentedCodeCache
+
+  }
+}

--- a/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/benchmark/StressTests.scala
+++ b/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/benchmark/StressTests.scala
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2023 RAW Labs S.A.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0, included in the file
+ * licenses/APL.txt.
+ */
+
 package raw.compiler.rql2.tests.benchmark
 
 import raw.compiler.rql2.tests.CompilerTestContext


### PR DESCRIPTION
Added stress test to test code cache behavior when running multiple queries. The test won't run by default.