### PR TITLE
RD-9242 Missing tests run in snapi

### DIFF
--- a/tests.sh
+++ b/tests.sh
@@ -5,4 +5,4 @@ cd "${SCRIPT_HOME}"
 rm -rfv test-results
 mkdir -p test-results
 
-sbt "testOnly * -- -n raw.testing.tags.TruffleTests"
+sbt test


### PR DESCRIPTION
We were using some legacy script testing only some part of the projects.
Now we are back testting them all in this repo context