### PR TITLE
fix: bump kiama dep to 2.5.1 (RD-9183 + RD-9185)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -34,8 +34,8 @@ object Dependencies {
   val loki4jAppender = "com.github.loki4j" % "loki-logback-appender" % "1.4.0"
 
   val kiama = Seq(
-    "org.bitbucket.inkytonik.kiama" %% "kiama" % "2.5.0",
-    "org.bitbucket.inkytonik.kiama" %% "kiama-extras" % "2.5.0"
+    "org.bitbucket.inkytonik.kiama" %% "kiama" % "2.5.1",
+    "org.bitbucket.inkytonik.kiama" %% "kiama-extras" % "2.5.1"
   )
 
   val ehCache = "org.ehcache" % "ehcache" % "3.10.6"


### PR DESCRIPTION
The current version is causing a transitive dep vuln issue (check JIRA for more details)

Thanks to @inkytonik responsivness on https://github.com/inkytonik/kiama/pull/33 and https://github.com/inkytonik/kiama/pull/34 we can now bump to `2.5.1`