### PR TITLE
RD-9240 Address temporary credentials in AWS library

### DIFF
--- a/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/builtin/TruffleAwsPackage.scala
+++ b/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/builtin/TruffleAwsPackage.scala
@@ -64,7 +64,19 @@ class AwsV4SignedRequestEntry extends AwsV4SignedRequest with TruffleEntryExtens
 
     val region = maybeRegion.getOrElse(new StringNode("us-east-1"))
 
-    AwsV4SignedRequestNodeGen.create(key, secretKey, service, region, sessionToken, path, method, host, body, urlParams, headers)
+    AwsV4SignedRequestNodeGen.create(
+      key,
+      secretKey,
+      service,
+      region,
+      sessionToken,
+      path,
+      method,
+      host,
+      body,
+      urlParams,
+      headers
+    )
   }
 
 }

--- a/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/builtin/TruffleAwsPackage.scala
+++ b/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/builtin/TruffleAwsPackage.scala
@@ -14,16 +14,13 @@ package raw.compiler.rql2.truffle.builtin
 
 import raw.compiler.base.source.Type
 import raw.compiler.rql2.builtin.AwsV4SignedRequest
-import raw.compiler.rql2.source.{Rql2AttrType, Rql2ListType, Rql2RecordType, Rql2StringType}
+import raw.compiler.rql2.source.{Rql2ListType, Rql2RecordType}
 import raw.compiler.rql2.truffle.{TruffleArg, TruffleEntryExtension}
 import raw.runtime.truffle.ExpressionNode
 import raw.runtime.truffle.ast.expressions.binary.PlusNode
 import raw.runtime.truffle.ast.expressions.builtin.aws_package.AwsV4SignedRequestNodeGen
 import raw.runtime.truffle.ast.expressions.iterable.list.ListBuildNode
-import raw.runtime.truffle.ast.expressions.literals.{FloatNode, LongNode, StringNode}
-import raw.runtime.truffle.ast.expressions.option.{OptionNoneNode, OptionSomeNode}
-import raw.runtime.truffle.ast.expressions.record.RecordBuildNode
-import raw.runtime.truffle.runtime.option.StringOption
+import raw.runtime.truffle.ast.expressions.literals.StringNode
 
 class AwsV4SignedRequestEntry extends AwsV4SignedRequest with TruffleEntryExtension {
 

--- a/raw-compiler-rql2-truffle/src/test/scala/raw/compiler/rql2/tests/extensions/TruffleExtensionsTest.scala
+++ b/raw-compiler-rql2-truffle/src/test/scala/raw/compiler/rql2/tests/extensions/TruffleExtensionsTest.scala
@@ -15,4 +15,4 @@ package raw.compiler.rql2.tests.extensions
 import raw.compiler.rql2.tests.TruffleCompilerTestContext
 import raw.testing.tags.TruffleTests
 
-// @TruffleTests class AwsPackageTruffleTest extends TruffleCompilerTestContext with AwsPackageTest
+@TruffleTests class AwsPackageTruffleTest extends TruffleCompilerTestContext with AwsPackageTest

--- a/raw-compiler-rql2-truffle/src/test/scala/raw/compiler/rql2/tests/extensions/TruffleExtensionsTest.scala
+++ b/raw-compiler-rql2-truffle/src/test/scala/raw/compiler/rql2/tests/extensions/TruffleExtensionsTest.scala
@@ -15,4 +15,6 @@ package raw.compiler.rql2.tests.extensions
 import raw.compiler.rql2.tests.TruffleCompilerTestContext
 import raw.testing.tags.TruffleTests
 
-@TruffleTests class AwsPackageTruffleTest extends TruffleCompilerTestContext with AwsPackageTest
+@TruffleTests class AwsPackageTruffleTest extends TruffleCompilerTestContext with AwsPackageTest {
+  override def xmlImplemented: Boolean = false
+}

--- a/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/builtin/AwsPackage.scala
+++ b/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/builtin/AwsPackage.scala
@@ -39,6 +39,7 @@ class AwsV4SignedRequest extends EntryExtension {
       ParamDoc("secretKey", TypeDoc(List("string")), "AWS secret key."),
       ParamDoc("service", TypeDoc(List("string")), "AWS service name e.g.: 'ec2'."),
       ParamDoc("region", TypeDoc(List("string")), "AWS region e.g.: 'us-east-1'.", isOptional = true),
+      ParamDoc("sessionToken", TypeDoc(List("string")), "AWS session token.", isOptional = true),
       ParamDoc(
         "path",
         TypeDoc(List("string")),
@@ -89,11 +90,11 @@ class AwsV4SignedRequest extends EntryExtension {
   override def nrMandatoryParams: Int = 3
 
   override def optionalParams: Option[Set[String]] =
-    Some(Set("region", "method", "host", "bodyString", "args", "headers", "path"))
+    Some(Set("region", "sessionToken", "method", "host", "bodyString", "args", "headers", "path"))
 
   override def getOptionalParam(prevMandatoryArgs: Seq[Arg], idn: String): Either[String, Param] = {
     idn match {
-      case "region" | "path" | "method" | "host" | "bodyString" => Right(ExpParam(Rql2StringType()))
+      case "region" | "sessionToken" | "path" | "method" | "host" | "bodyString" => Right(ExpParam(Rql2StringType()))
       case "args" | "headers" => Right(
           ExpParam(
             Rql2ListType(

--- a/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/builtin/CsvPackageTest.scala
+++ b/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/builtin/CsvPackageTest.scala
@@ -505,4 +505,24 @@ trait CsvPackageTest extends CompilerTestContext with FailAfterNServer {
     s"""Csv.InferAndParse(${ttt}1;2\n3;hello;5;;;;;;;$ttt, delimiters=[";","\\n"])""".stripMargin
   )(_ should evaluateTo("""[]"""))
 
+  test(
+    rql"""Csv.Read("$data", type collection(record(_1: int, _2: int, _3: int)), delimiter="|", escape="\\", quote="\"")"""
+  )(it => it should run)
+
+  test(
+    rql"""Csv.Read("$data", type collection(record(_1: int, _2: int, _3: int)), delimiter="|", escape=null, quote=null)"""
+  )(it => it should run)
+
+  test(rql"""Csv.InferAndRead("$data", escape="\\", quotes=["\""])""")(it => it should run)
+
+  test(rql"""Csv.Parse("1,2,3", type collection(record(_1: int, _2: int, _3: int)), escape="\\", quote="\"")""")(it =>
+    it should run
+  )
+
+  test(rql"""Csv.Parse("1,2,3", type collection(record(_1: int, _2: int, _3: int)), escape=null, quote=null)""")(it =>
+    it should run
+  )
+
+  test(rql"""Csv.InferAndParse("1,2,3", escape="\\", quotes=["\""])""")(it => it should run)
+
 }

--- a/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/extensions/AwsPackageTest.scala
+++ b/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/extensions/AwsPackageTest.scala
@@ -20,91 +20,89 @@ trait AwsPackageTest extends CompilerTestContext {
   val abraxasSecretAccessKey = sys.env("RAW_ABRAXAS_SECRET_ACCESS_KEY")
 
   secret(authorizedUser, "abraxas-secret-key", abraxasSecretAccessKey)
-
   secret(authorizedUser, "abraxas-key", abraxasAccessKeyId)
-
-  val triple = "\"\"\""
 
   val awsSessionToken = sys.env("AWS_SESSION_TOKEN")
   val awsAccessKeyId = sys.env("AWS_ACCESS_KEY_ID")
   val awsSecretAccessKey = sys.env("AWS_SECRET_ACCESS_KEY")
 
-//
-//  test("""let data = Xml.Read(
-//    |    Aws.SignedV4Request(
-//    |       Environment.Secret("abraxas-key"),
-//    |       Environment.Secret("abraxas-secret-key"),
-//    |       "ec2",
-//    |       args = [
-//    |         {"Action", "DescribeRegions"},
-//    |         {"Version", "2013-10-15"}
-//    |       ]
-//    |    ),
-//    |    type record(requestId: string, regionInfo: record(item: list(record(regionName: string, regionEndpoint: string))))
-//    |)
-//    |in List.Filter(data.regionInfo.item, x -> x.regionName == "eu-west-1")
-//    |""".stripMargin)(
-//    _ should evaluateTo("""[ {regionName: "eu-west-1", regionEndpoint: "ec2.eu-west-1.amazonaws.com"} ]""")
-//  )
-//
-//  test("""let data = Xml.Read(
-//    |    Aws.SignedV4Request(
-//    |       Environment.Secret("abraxas-key"),
-//    |       Environment.Secret("abraxas-secret-key"),
-//    |       "ec2",
-//    |       region = "us-east-1",
-//    |       host = "ec2.amazonaws.com",
-//    |       args = [
-//    |         {"Action", "DescribeRegions"},
-//    |         {"Version", "2013-10-15"}
-//    |       ]
-//    |    ),
-//    |    type record(requestId: string, regionInfo: record(item: list(record(regionName: string, regionEndpoint: string))))
-//    |)
-//    |in List.Filter(data.regionInfo.item, x -> x.regionName == "eu-west-1")
-//    |""".stripMargin)(
-//    _ should evaluateTo("""[ {regionName: "eu-west-1", regionEndpoint: "ec2.eu-west-1.amazonaws.com"} ]""")
-//  )
-//
-//  test("""let data = Xml.Read(
-//    |    Aws.SignedV4Request(
-//    |       Environment.Secret("abraxas-key"),
-//    |       Environment.Secret("abraxas-secret-key"),
-//    |       "ec2",
-//    |       region = "us-east-1",
-//    |       host = "ec2.amazonaws.com",
-//    |       path = "/",
-//    |       args = [
-//    |         {"Action", "DescribeRegions"},
-//    |         {"Version", "2013-10-15"}
-//    |       ]
-//    |    ),
-//    |    type record(requestId: string, regionInfo: record(item: list(record(regionName: string, regionEndpoint: string))))
-//    |  )
-//    |in List.Filter(data.regionInfo.item, x -> x.regionName == "eu-west-1")
-//    |""".stripMargin)(
-//    _ should evaluateTo("""[ {regionName: "eu-west-1", regionEndpoint: "ec2.eu-west-1.amazonaws.com"} ]""")
-//  )
-//
-//  test("""let data = Xml.InferAndRead(
-//    |    Aws.SignedV4Request(
-//    |       Environment.Secret("abraxas-key"),
-//    |       Environment.Secret("abraxas-secret-key"),
-//    |       "ec2",
-//    |       args = [
-//    |         {"Action", "DescribeRegions"},
-//    |         {"Version", "2013-10-15"}
-//    |       ]
-//    |    )
-//    |)
-//    |in Collection.Filter(data.regionInfo.item, x -> x.regionName == "eu-west-1")
-//    |""".stripMargin)(
-//    _ should evaluateTo("""[ {regionName: "eu-west-1", regionEndpoint: "ec2.eu-west-1.amazonaws.com"} ]""")
-//  )
-
   secret(authorizedUser, "temporary-key", awsAccessKeyId)
   secret(authorizedUser, "temporary-secret-key", awsSecretAccessKey)
   secret(authorizedUser, "session-token", awsSessionToken)
+
+  val triple = "\"\"\""
+
+  ignore("""let data = Xml.Read(
+    |    Aws.SignedV4Request(
+    |       Environment.Secret("abraxas-key"),
+    |       Environment.Secret("abraxas-secret-key"),
+    |       "ec2",
+    |       args = [
+    |         {"Action", "DescribeRegions"},
+    |         {"Version", "2013-10-15"}
+    |       ]
+    |    ),
+    |    type record(requestId: string, regionInfo: record(item: list(record(regionName: string, regionEndpoint: string))))
+    |)
+    |in List.Filter(data.regionInfo.item, x -> x.regionName == "eu-west-1")
+    |""".stripMargin)(
+    _ should evaluateTo("""[ {regionName: "eu-west-1", regionEndpoint: "ec2.eu-west-1.amazonaws.com"} ]""")
+  )
+
+  ignore("""let data = Xml.Read(
+    |    Aws.SignedV4Request(
+    |       Environment.Secret("abraxas-key"),
+    |       Environment.Secret("abraxas-secret-key"),
+    |       "ec2",
+    |       region = "us-east-1",
+    |       host = "ec2.amazonaws.com",
+    |       args = [
+    |         {"Action", "DescribeRegions"},
+    |         {"Version", "2013-10-15"}
+    |       ]
+    |    ),
+    |    type record(requestId: string, regionInfo: record(item: list(record(regionName: string, regionEndpoint: string))))
+    |)
+    |in List.Filter(data.regionInfo.item, x -> x.regionName == "eu-west-1")
+    |""".stripMargin)(
+    _ should evaluateTo("""[ {regionName: "eu-west-1", regionEndpoint: "ec2.eu-west-1.amazonaws.com"} ]""")
+  )
+
+  ignore("""let data = Xml.Read(
+    |    Aws.SignedV4Request(
+    |       Environment.Secret("abraxas-key"),
+    |       Environment.Secret("abraxas-secret-key"),
+    |       "ec2",
+    |       region = "us-east-1",
+    |       host = "ec2.amazonaws.com",
+    |       path = "/",
+    |       args = [
+    |         {"Action", "DescribeRegions"},
+    |         {"Version", "2013-10-15"}
+    |       ]
+    |    ),
+    |    type record(requestId: string, regionInfo: record(item: list(record(regionName: string, regionEndpoint: string))))
+    |  )
+    |in List.Filter(data.regionInfo.item, x -> x.regionName == "eu-west-1")
+    |""".stripMargin)(
+    _ should evaluateTo("""[ {regionName: "eu-west-1", regionEndpoint: "ec2.eu-west-1.amazonaws.com"} ]""")
+  )
+
+  ignore("""let data = Xml.InferAndRead(
+    |    Aws.SignedV4Request(
+    |       Environment.Secret("abraxas-key"),
+    |       Environment.Secret("abraxas-secret-key"),
+    |       "ec2",
+    |       args = [
+    |         {"Action", "DescribeRegions"},
+    |         {"Version", "2013-10-15"}
+    |       ]
+    |    )
+    |)
+    |in Collection.Filter(data.regionInfo.item, x -> x.regionName == "eu-west-1")
+    |""".stripMargin)(
+    _ should evaluateTo("""[ {regionName: "eu-west-1", regionEndpoint: "ec2.eu-west-1.amazonaws.com"} ]""")
+  )
 
   test(
     s"""let query = $triple{"endTime": 1665655502, "limit": 1000, "logGroupName": "/aws/lambda/auth-proxy-v2-lambda-prod", "queryString": "fields @timestamp, @message, @clientTag, @username | limit 200", "startTime": 1665396297}$triple
@@ -174,7 +172,7 @@ trait AwsPackageTest extends CompilerTestContext {
   )(_ should run)
 
   // listing ec2 instances
-  test("""let data = Xml.Read(
+  ignore("""let data = Xml.Read(
     |   Aws.SignedV4Request(
     |       Environment.Secret("abraxas-key"),
     |       Environment.Secret("abraxas-secret-key"),
@@ -204,36 +202,37 @@ trait AwsPackageTest extends CompilerTestContext {
     |""".stripMargin)(it => it should run)
 
   // Using iam to list users.
-//  test("""let data = Xml.Read(
-//    |   Aws.SignedV4Request(
-//    |       Environment.Secret("abraxas-key"),
-//    |       Environment.Secret("abraxas-secret-key"),
-//    |       "iam",
-//    |       args = [
-//    |         {"Action", "ListUsers"},
-//    |         {"Version", "2010-05-08"},
-//    |         {"PathPrefix", "/examples/"}
-//    |       ]
-//    |    ),
-//    |    type record(ListUsersResult: record(
-//    |        IsTruncated: bool,
-//    |        Users: record(
-//    |            member: list(record(
-//    |                Path: string,
-//    |                UserName: string,
-//    |                Arn: string,
-//    |                UserId: string,
-//    |                CreateDate: string
-//    |            ))
-//    |        )
-//    |    ))
-//    |)
-//    |in List.Filter(data.ListUsersResult.Users.member, x -> x.UserName == "abraxas").UserName
-//    |
-//    |""".stripMargin)(it => it should evaluateTo(""" ["abraxas" ] """))
+  ignore("""let data = Xml.Read(
+    |   Aws.SignedV4Request(
+    |       Environment.Secret("abraxas-key"),
+    |       Environment.Secret("abraxas-secret-key"),
+    |       "iam",
+    |       args = [
+    |         {"Action", "ListUsers"},
+    |         {"Version", "2010-05-08"},
+    |         {"PathPrefix", "/examples/"}
+    |       ]
+    |    ),
+    |    type record(ListUsersResult: record(
+    |        IsTruncated: bool,
+    |        Users: record(
+    |            member: list(record(
+    |                Path: string,
+    |                UserName: string,
+    |                Arn: string,
+    |                UserId: string,
+    |                CreateDate: string
+    |            ))
+    |        )
+    |    ))
+    |)
+    |in List.Filter(data.ListUsersResult.Users.member, x -> x.UserName == "abraxas").UserName
+    |
+    |""".stripMargin)(it => it should evaluateTo(""" ["abraxas" ] """))
 
   // querying monitoring aka could-watch to get cpu usage
-  test(s"""
+  // this test is failing with Non-terminating decimal expansion; no exact representable decimal result.
+    test(s"""
     |let query = Json.Print({
     |       StartTime: Timestamp.ToUnixTimestamp(Timestamp.Build(2022,10,11, 23, 0)),
     |       EndTime: Timestamp.ToUnixTimestamp(Timestamp.Build(2022,10,12, 23, 0)),

--- a/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/extensions/AwsPackageTest.scala
+++ b/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/extensions/AwsPackageTest.scala
@@ -25,77 +25,103 @@ trait AwsPackageTest extends CompilerTestContext {
 
   val triple = "\"\"\""
 
-  test("""let data = Xml.Read(
-    |    Aws.SignedV4Request(
-    |       Environment.Secret("abraxas-key"),
-    |       Environment.Secret("abraxas-secret-key"),
-    |       "ec2",
-    |       args = [
-    |         {"Action", "DescribeRegions"},
-    |         {"Version", "2013-10-15"}
-    |       ]
-    |    ),
-    |    type record(requestId: string, regionInfo: record(item: list(record(regionName: string, regionEndpoint: string))))
-    |)
-    |in List.Filter(data.regionInfo.item, x -> x.regionName == "eu-west-1")
-    |""".stripMargin)(
-    _ should evaluateTo("""[ {regionName: "eu-west-1", regionEndpoint: "ec2.eu-west-1.amazonaws.com"} ]""")
-  )
+  val awsSessionToken = sys.env("AWS_SESSION_TOKEN")
+  val awsAccessKeyId = sys.env("AWS_ACCESS_KEY_ID")
+  val awsSecretAccessKey = sys.env("AWS_SECRET_ACCESS_KEY")
 
-  test("""let data = Xml.Read(
-    |    Aws.SignedV4Request(
-    |       Environment.Secret("abraxas-key"),
-    |       Environment.Secret("abraxas-secret-key"),
-    |       "ec2",
-    |       region = "us-east-1",
-    |       host = "ec2.amazonaws.com",
-    |       args = [
-    |         {"Action", "DescribeRegions"},
-    |         {"Version", "2013-10-15"}
-    |       ]
-    |    ),
-    |    type record(requestId: string, regionInfo: record(item: list(record(regionName: string, regionEndpoint: string))))
-    |)
-    |in List.Filter(data.regionInfo.item, x -> x.regionName == "eu-west-1")
-    |""".stripMargin)(
-    _ should evaluateTo("""[ {regionName: "eu-west-1", regionEndpoint: "ec2.eu-west-1.amazonaws.com"} ]""")
-  )
+//
+//  test("""let data = Xml.Read(
+//    |    Aws.SignedV4Request(
+//    |       Environment.Secret("abraxas-key"),
+//    |       Environment.Secret("abraxas-secret-key"),
+//    |       "ec2",
+//    |       args = [
+//    |         {"Action", "DescribeRegions"},
+//    |         {"Version", "2013-10-15"}
+//    |       ]
+//    |    ),
+//    |    type record(requestId: string, regionInfo: record(item: list(record(regionName: string, regionEndpoint: string))))
+//    |)
+//    |in List.Filter(data.regionInfo.item, x -> x.regionName == "eu-west-1")
+//    |""".stripMargin)(
+//    _ should evaluateTo("""[ {regionName: "eu-west-1", regionEndpoint: "ec2.eu-west-1.amazonaws.com"} ]""")
+//  )
+//
+//  test("""let data = Xml.Read(
+//    |    Aws.SignedV4Request(
+//    |       Environment.Secret("abraxas-key"),
+//    |       Environment.Secret("abraxas-secret-key"),
+//    |       "ec2",
+//    |       region = "us-east-1",
+//    |       host = "ec2.amazonaws.com",
+//    |       args = [
+//    |         {"Action", "DescribeRegions"},
+//    |         {"Version", "2013-10-15"}
+//    |       ]
+//    |    ),
+//    |    type record(requestId: string, regionInfo: record(item: list(record(regionName: string, regionEndpoint: string))))
+//    |)
+//    |in List.Filter(data.regionInfo.item, x -> x.regionName == "eu-west-1")
+//    |""".stripMargin)(
+//    _ should evaluateTo("""[ {regionName: "eu-west-1", regionEndpoint: "ec2.eu-west-1.amazonaws.com"} ]""")
+//  )
+//
+//  test("""let data = Xml.Read(
+//    |    Aws.SignedV4Request(
+//    |       Environment.Secret("abraxas-key"),
+//    |       Environment.Secret("abraxas-secret-key"),
+//    |       "ec2",
+//    |       region = "us-east-1",
+//    |       host = "ec2.amazonaws.com",
+//    |       path = "/",
+//    |       args = [
+//    |         {"Action", "DescribeRegions"},
+//    |         {"Version", "2013-10-15"}
+//    |       ]
+//    |    ),
+//    |    type record(requestId: string, regionInfo: record(item: list(record(regionName: string, regionEndpoint: string))))
+//    |  )
+//    |in List.Filter(data.regionInfo.item, x -> x.regionName == "eu-west-1")
+//    |""".stripMargin)(
+//    _ should evaluateTo("""[ {regionName: "eu-west-1", regionEndpoint: "ec2.eu-west-1.amazonaws.com"} ]""")
+//  )
+//
+//  test("""let data = Xml.InferAndRead(
+//    |    Aws.SignedV4Request(
+//    |       Environment.Secret("abraxas-key"),
+//    |       Environment.Secret("abraxas-secret-key"),
+//    |       "ec2",
+//    |       args = [
+//    |         {"Action", "DescribeRegions"},
+//    |         {"Version", "2013-10-15"}
+//    |       ]
+//    |    )
+//    |)
+//    |in Collection.Filter(data.regionInfo.item, x -> x.regionName == "eu-west-1")
+//    |""".stripMargin)(
+//    _ should evaluateTo("""[ {regionName: "eu-west-1", regionEndpoint: "ec2.eu-west-1.amazonaws.com"} ]""")
+//  )
 
-  test("""let data = Xml.Read(
-    |    Aws.SignedV4Request(
-    |       Environment.Secret("abraxas-key"),
-    |       Environment.Secret("abraxas-secret-key"),
-    |       "ec2",
-    |       region = "us-east-1",
-    |       host = "ec2.amazonaws.com",
-    |       path = "/",
-    |       args = [
-    |         {"Action", "DescribeRegions"},
-    |         {"Version", "2013-10-15"}
-    |       ]
-    |    ),
-    |    type record(requestId: string, regionInfo: record(item: list(record(regionName: string, regionEndpoint: string))))
-    |  )
-    |in List.Filter(data.regionInfo.item, x -> x.regionName == "eu-west-1")
-    |""".stripMargin)(
-    _ should evaluateTo("""[ {regionName: "eu-west-1", regionEndpoint: "ec2.eu-west-1.amazonaws.com"} ]""")
-  )
+  secret(authorizedUser, "temporary-key", awsAccessKeyId)
+  secret(authorizedUser, "temporary-secret-key", awsSecretAccessKey)
+  secret(authorizedUser, "session-token", awsSessionToken)
 
-  test("""let data = Xml.InferAndRead(
-    |    Aws.SignedV4Request(
-    |       Environment.Secret("abraxas-key"),
-    |       Environment.Secret("abraxas-secret-key"),
-    |       "ec2",
-    |       args = [
-    |         {"Action", "DescribeRegions"},
-    |         {"Version", "2013-10-15"}
-    |       ]
-    |    )
-    |)
-    |in Collection.Filter(data.regionInfo.item, x -> x.regionName == "eu-west-1")
-    |""".stripMargin)(
-    _ should evaluateTo("""[ {regionName: "eu-west-1", regionEndpoint: "ec2.eu-west-1.amazonaws.com"} ]""")
-  )
+  test(
+    s"""let query = $triple{"endTime": 1665655502, "limit": 1000, "logGroupName": "/aws/lambda/auth-proxy-v2-lambda-prod", "queryString": "fields @timestamp, @message, @clientTag, @username | limit 200", "startTime": 1665396297}$triple
+      |in String.Read(
+      |   Aws.SignedV4Request(
+      |      Environment.Secret("temporary-key"),
+      |      Environment.Secret("temporary-secret-key"),
+      |      "logs",
+      |      sessionToken = Environment.Secret("session-token"),
+      |      region = "eu-west-1",
+      |      method = "POST",
+      |      bodyString = query,
+      |      headers = [{"x-amz-target", "Logs_20140328.StartQuery"}, {"content-type", "application/x-amz-json-1.1"}]
+      |   )
+      |)
+      |""".stripMargin
+  )(_ should run)
 
   test(
     s"""let query = $triple{"endTime": 1665655502, "limit": 1000, "logGroupName": "/aws/lambda/auth-proxy-v2-lambda-prod", "queryString": "fields @timestamp, @message, @clientTag, @username | limit 200", "startTime": 1665396297}$triple
@@ -178,33 +204,33 @@ trait AwsPackageTest extends CompilerTestContext {
     |""".stripMargin)(it => it should run)
 
   // Using iam to list users.
-  test("""let data = Xml.Read(
-    |   Aws.SignedV4Request(
-    |       Environment.Secret("abraxas-key"),
-    |       Environment.Secret("abraxas-secret-key"),
-    |       "iam",
-    |       args = [
-    |         {"Action", "ListUsers"},
-    |         {"Version", "2010-05-08"},
-    |         {"PathPrefix", "/examples/"}
-    |       ]
-    |    ),
-    |    type record(ListUsersResult: record(
-    |        IsTruncated: bool,
-    |        Users: record(
-    |            member: list(record(
-    |                Path: string,
-    |                UserName: string,
-    |                Arn: string,
-    |                UserId: string,
-    |                CreateDate: string
-    |            ))
-    |        )
-    |    ))
-    |)
-    |in List.Filter(data.ListUsersResult.Users.member, x -> x.UserName == "abraxas").UserName
-    |
-    |""".stripMargin)(it => it should evaluateTo(""" ["abraxas" ] """))
+//  test("""let data = Xml.Read(
+//    |   Aws.SignedV4Request(
+//    |       Environment.Secret("abraxas-key"),
+//    |       Environment.Secret("abraxas-secret-key"),
+//    |       "iam",
+//    |       args = [
+//    |         {"Action", "ListUsers"},
+//    |         {"Version", "2010-05-08"},
+//    |         {"PathPrefix", "/examples/"}
+//    |       ]
+//    |    ),
+//    |    type record(ListUsersResult: record(
+//    |        IsTruncated: bool,
+//    |        Users: record(
+//    |            member: list(record(
+//    |                Path: string,
+//    |                UserName: string,
+//    |                Arn: string,
+//    |                UserId: string,
+//    |                CreateDate: string
+//    |            ))
+//    |        )
+//    |    ))
+//    |)
+//    |in List.Filter(data.ListUsersResult.Users.member, x -> x.UserName == "abraxas").UserName
+//    |
+//    |""".stripMargin)(it => it should evaluateTo(""" ["abraxas" ] """))
 
   // querying monitoring aka could-watch to get cpu usage
   test(s"""

--- a/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/extensions/AwsPackageTest.scala
+++ b/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/extensions/AwsPackageTest.scala
@@ -22,14 +22,6 @@ trait AwsPackageTest extends CompilerTestContext {
   secret(authorizedUser, "abraxas-secret-key", abraxasSecretAccessKey)
   secret(authorizedUser, "abraxas-key", abraxasAccessKeyId)
 
-  val awsSessionToken = sys.env("AWS_SESSION_TOKEN")
-  val awsAccessKeyId = sys.env("AWS_ACCESS_KEY_ID")
-  val awsSecretAccessKey = sys.env("AWS_SECRET_ACCESS_KEY")
-
-  secret(authorizedUser, "temporary-key", awsAccessKeyId)
-  secret(authorizedUser, "temporary-secret-key", awsSecretAccessKey)
-  secret(authorizedUser, "session-token", awsSessionToken)
-
   def xmlImplemented: Boolean
 
   val triple = "\"\"\""
@@ -109,23 +101,6 @@ trait AwsPackageTest extends CompilerTestContext {
     assume(xmlImplemented)
     it should evaluateTo("""[ {regionName: "eu-west-1", regionEndpoint: "ec2.eu-west-1.amazonaws.com"} ]""")
   }
-
-  test(
-    s"""let query = $triple{"endTime": 1665655502, "limit": 1000, "logGroupName": "/aws/lambda/auth-proxy-v2-lambda-prod", "queryString": "fields @timestamp, @message, @clientTag, @username | limit 200", "startTime": 1665396297}$triple
-      |in String.Read(
-      |   Aws.SignedV4Request(
-      |      Environment.Secret("temporary-key"),
-      |      Environment.Secret("temporary-secret-key"),
-      |      "logs",
-      |      sessionToken = Environment.Secret("session-token"),
-      |      region = "eu-west-1",
-      |      method = "POST",
-      |      bodyString = query,
-      |      headers = [{"x-amz-target", "Logs_20140328.StartQuery"}, {"content-type", "application/x-amz-json-1.1"}]
-      |   )
-      |)
-      |""".stripMargin
-  )(_ should run)
 
   test(
     s"""let query = $triple{"endTime": 1665655502, "limit": 1000, "logGroupName": "/aws/lambda/auth-proxy-v2-lambda-prod", "queryString": "fields @timestamp, @message, @clientTag, @username | limit 200", "startTime": 1665396297}$triple

--- a/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/extensions/AwsPackageTest.scala
+++ b/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/extensions/AwsPackageTest.scala
@@ -30,9 +30,11 @@ trait AwsPackageTest extends CompilerTestContext {
   secret(authorizedUser, "temporary-secret-key", awsSecretAccessKey)
   secret(authorizedUser, "session-token", awsSessionToken)
 
+  def xmlImplemented: Boolean
+
   val triple = "\"\"\""
 
-  ignore("""let data = Xml.Read(
+  test("""let data = Xml.Read(
     |    Aws.SignedV4Request(
     |       Environment.Secret("abraxas-key"),
     |       Environment.Secret("abraxas-secret-key"),
@@ -45,11 +47,12 @@ trait AwsPackageTest extends CompilerTestContext {
     |    type record(requestId: string, regionInfo: record(item: list(record(regionName: string, regionEndpoint: string))))
     |)
     |in List.Filter(data.regionInfo.item, x -> x.regionName == "eu-west-1")
-    |""".stripMargin)(
-    _ should evaluateTo("""[ {regionName: "eu-west-1", regionEndpoint: "ec2.eu-west-1.amazonaws.com"} ]""")
-  )
+    |""".stripMargin) { it =>
+    assume(xmlImplemented)
+    it should evaluateTo("""[ {regionName: "eu-west-1", regionEndpoint: "ec2.eu-west-1.amazonaws.com"} ]""")
+  }
 
-  ignore("""let data = Xml.Read(
+  test("""let data = Xml.Read(
     |    Aws.SignedV4Request(
     |       Environment.Secret("abraxas-key"),
     |       Environment.Secret("abraxas-secret-key"),
@@ -64,11 +67,12 @@ trait AwsPackageTest extends CompilerTestContext {
     |    type record(requestId: string, regionInfo: record(item: list(record(regionName: string, regionEndpoint: string))))
     |)
     |in List.Filter(data.regionInfo.item, x -> x.regionName == "eu-west-1")
-    |""".stripMargin)(
-    _ should evaluateTo("""[ {regionName: "eu-west-1", regionEndpoint: "ec2.eu-west-1.amazonaws.com"} ]""")
-  )
+    |""".stripMargin) { it =>
+    assume(xmlImplemented)
+    it should evaluateTo("""[ {regionName: "eu-west-1", regionEndpoint: "ec2.eu-west-1.amazonaws.com"} ]""")
+  }
 
-  ignore("""let data = Xml.Read(
+  test("""let data = Xml.Read(
     |    Aws.SignedV4Request(
     |       Environment.Secret("abraxas-key"),
     |       Environment.Secret("abraxas-secret-key"),
@@ -84,11 +88,12 @@ trait AwsPackageTest extends CompilerTestContext {
     |    type record(requestId: string, regionInfo: record(item: list(record(regionName: string, regionEndpoint: string))))
     |  )
     |in List.Filter(data.regionInfo.item, x -> x.regionName == "eu-west-1")
-    |""".stripMargin)(
-    _ should evaluateTo("""[ {regionName: "eu-west-1", regionEndpoint: "ec2.eu-west-1.amazonaws.com"} ]""")
-  )
+    |""".stripMargin) { it =>
+    assume(xmlImplemented)
+    it should evaluateTo("""[ {regionName: "eu-west-1", regionEndpoint: "ec2.eu-west-1.amazonaws.com"} ]""")
+  }
 
-  ignore("""let data = Xml.InferAndRead(
+  test("""let data = Xml.InferAndRead(
     |    Aws.SignedV4Request(
     |       Environment.Secret("abraxas-key"),
     |       Environment.Secret("abraxas-secret-key"),
@@ -100,9 +105,10 @@ trait AwsPackageTest extends CompilerTestContext {
     |    )
     |)
     |in Collection.Filter(data.regionInfo.item, x -> x.regionName == "eu-west-1")
-    |""".stripMargin)(
-    _ should evaluateTo("""[ {regionName: "eu-west-1", regionEndpoint: "ec2.eu-west-1.amazonaws.com"} ]""")
-  )
+    |""".stripMargin) { it =>
+    assume(xmlImplemented)
+    it should evaluateTo("""[ {regionName: "eu-west-1", regionEndpoint: "ec2.eu-west-1.amazonaws.com"} ]""")
+  }
 
   test(
     s"""let query = $triple{"endTime": 1665655502, "limit": 1000, "logGroupName": "/aws/lambda/auth-proxy-v2-lambda-prod", "queryString": "fields @timestamp, @message, @clientTag, @username | limit 200", "startTime": 1665396297}$triple
@@ -172,7 +178,7 @@ trait AwsPackageTest extends CompilerTestContext {
   )(_ should run)
 
   // listing ec2 instances
-  ignore("""let data = Xml.Read(
+  test("""let data = Xml.Read(
     |   Aws.SignedV4Request(
     |       Environment.Secret("abraxas-key"),
     |       Environment.Secret("abraxas-secret-key"),
@@ -199,10 +205,13 @@ trait AwsPackageTest extends CompilerTestContext {
     |)
     |in Collection.Count(data.reservationSet.item)
     |
-    |""".stripMargin)(it => it should run)
+    |""".stripMargin) { it =>
+    assume(xmlImplemented)
+    it should run
+  }
 
   // Using iam to list users.
-  ignore("""let data = Xml.Read(
+  test("""let data = Xml.Read(
     |   Aws.SignedV4Request(
     |       Environment.Secret("abraxas-key"),
     |       Environment.Secret("abraxas-secret-key"),
@@ -228,7 +237,10 @@ trait AwsPackageTest extends CompilerTestContext {
     |)
     |in List.Filter(data.ListUsersResult.Users.member, x -> x.UserName == "abraxas").UserName
     |
-    |""".stripMargin)(it => it should evaluateTo(""" ["abraxas" ] """))
+    |""".stripMargin) { it =>
+    assume(xmlImplemented)
+    it should evaluateTo(""" ["abraxas" ] """)
+  }
 
   // querying monitoring aka could-watch to get cpu usage
   // this test was failing with Non-terminating decimal expansion; no exact representable decimal result.

--- a/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/extensions/AwsPackageTest.scala
+++ b/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/extensions/AwsPackageTest.scala
@@ -231,8 +231,8 @@ trait AwsPackageTest extends CompilerTestContext {
     |""".stripMargin)(it => it should evaluateTo(""" ["abraxas" ] """))
 
   // querying monitoring aka could-watch to get cpu usage
-  // this test is failing with Non-terminating decimal expansion; no exact representable decimal result.
-    test(s"""
+  // this test was failing with Non-terminating decimal expansion; no exact representable decimal result.
+  test(s"""
     |let query = Json.Print({
     |       StartTime: Timestamp.ToUnixTimestamp(Timestamp.Build(2022,10,11, 23, 0)),
     |       EndTime: Timestamp.ToUnixTimestamp(Timestamp.Build(2022,10,12, 23, 0)),

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/expressions/binary/DivNode.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/expressions/binary/DivNode.java
@@ -18,6 +18,8 @@ import raw.runtime.truffle.ast.BinaryNode;
 import raw.runtime.truffle.runtime.tryable.*;
 
 import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
 
 // TODO: further optimization could be done by creating permutations of types?
 // if we divide 500.0 by 500.0 the result could fit into int, should we specialize that case?
@@ -57,6 +59,11 @@ public abstract class DivNode extends BinaryNode {
 
     @Specialization
     protected ObjectTryable divDecimal(BigDecimal a, BigDecimal b) {
-        return b.doubleValue() != 0 ? ObjectTryable.BuildSuccess(a.divide(b)) : ObjectTryable.BuildFailure("/ by zero");
+        // Without the MathContext.DECIMAL128, we would get a:
+        // java.lang.ArithmeticException: Non-terminating decimal expansion; no exact representable decimal result.
+        // MathContext DECIMAL128 = new MathContext(34, RoundingMode.HALF_EVEN);
+        // This means 34 digits before rounding
+        // TODO: Check if this the rounding mode we want.
+        return b.doubleValue() != 0 ? ObjectTryable.BuildSuccess(a.divide(b, MathContext.DECIMAL128)) : ObjectTryable.BuildFailure("/ by zero");
     }
 }

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/expressions/builtin/aws_package/AwsV4SignedRequestNode.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/expressions/builtin/aws_package/AwsV4SignedRequestNode.java
@@ -155,8 +155,6 @@ public abstract class AwsV4SignedRequestNode extends ExpressionNode {
                 canonicalQueryBuilder.deleteCharAt(canonicalQueryBuilder.length() - 1);
             }
 
-            String canonicalQueryString = canonicalQueryBuilder.toString();
-
             // Create the canonical headers and signed headers.
             // Header names must be trimmed and lowercase, and sorted in code point order from
             // low to high. Note that there is a trailing \n.
@@ -210,8 +208,6 @@ public abstract class AwsV4SignedRequestNode extends ExpressionNode {
                 signedHeadersBuilder.deleteCharAt(signedHeadersBuilder.length() - 1);
             }
 
-            String canonicalHeaders = canonicalHeadersBuilder.toString();
-
             // List of signed headers: lists the headers in the canonical_headers list, delimited with ";".
             String signedHeaders = signedHeadersBuilder.toString();
 
@@ -219,9 +215,9 @@ public abstract class AwsV4SignedRequestNode extends ExpressionNode {
 
             String canonicalRequest = method + "\n" +
                     path + "\n" +
-                    canonicalQueryString + "\n" +
-                    canonicalHeaders + "\n" +
-                    signedHeaders + "\n" +
+                    canonicalQueryBuilder + "\n" +
+                    canonicalHeadersBuilder + "\n" +
+                    signedHeadersBuilder + "\n" +
                     payloadHash;
 
             // Task 2: create string to sign
@@ -249,6 +245,10 @@ public abstract class AwsV4SignedRequestNode extends ExpressionNode {
             VectorBuilder<Tuple2<String, String>> newHeaders = new VectorBuilder<>();
             newHeaders.$plus$eq(new Tuple2<>("x-amz-date", amzdate));
             newHeaders.$plus$eq(new Tuple2<>("Authorization", authorizationHeader));
+            if (!sessionToken.equals("")) {
+                newHeaders.$plus$eq(new Tuple2<>("x-amz-security-token", sessionToken));
+            }
+
             VectorBuilder<Tuple2<String, String>> requestHeaders = newHeaders.$plus$plus$eq(headersParamsVec.result());
 
             // host is added automatically


### PR DESCRIPTION
I enabled back the aws truffle tests. ignored for the moment the ones that use xml as it is not implemented in truffle.

One thing to discuss before merging how to generate in the CI the environment variables for the credentials 
```
"AWS_SESSION_TOKEN"
"AWS_ACCESS_KEY_ID"
"AWS_SECRET_ACCESS_KEY"
```

A script that I used to generate these (Pavlos gracefully gave it to me). Maybe it helps
```
#!/bin/bash
role_name=Developers
account_id=<your account id>
aws sso login
file=$(find ~/.aws/sso/cache/ -type f -printf "%t - %p\n" | sort -nr | tail -1 | awk '{print $7}')
access_token=$(cat  $file| jq -r .accessToken)
rc=$(aws sso get-role-credentials --account-id $account_id --role-name $role_name --region eu-west-1 --access-token $access_token | jq .)
export AWS_ACCESS_KEY_ID=$(echo $rc | jq -r .roleCredentials.accessKeyId)
export AWS_SECRET_ACCESS_KEY=$(echo $rc | jq -r .roleCredentials.secretAccessKey)
export AWS_SESSION_TOKEN=$(echo $rc | jq -r .roleCredentials.sessionToken)
```
