### PR TITLE
RD-9292 + RD-9293 + RD-9245 automatic github release

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -59,6 +59,12 @@ jobs:
         CI_CLEAN: clean
         CI_RELEASE: publishSigned
         CI_SNAPSHOT_RELEASE: publish
+    - if: success() && github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+      uses: peter-evans/repository-dispatch@v2
+      with:
+        token: ${{ secrets.RAW_CI_PAT }}
+        event-type: release
+        client-payload: '{"ref": "${{ github.ref }}", "tag": "${{ github.ref_name }}"}'
     - if: success() && github.event_name == 'repository_dispatch'
       uses: peter-evans/create-or-update-comment@v2
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,30 @@
+name: release
+on:
+  repository_dispatch:
+    types: [release]
+jobs:
+  code-checks:
+    runs-on: self-hosted
+    container:
+      image: ghcr.io/raw-labs/raw-scala-runner:ol8_java17_gvm22.3.0_scala2.12.15_sbt1.6.2
+      options: --user 1001
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.READ_PACKAGES }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.client_payload.ref }}
+      - run: ./rebuild.sh
+      - run: sbt buildSnapi
+      - uses: softprops/action-gh-release@v1
+        with:
+          token: "${{ secrets.RAW_CI_PAT }}"
+          generate_release_notes: true
+          fail_on_unmatched_files	: true
+          draft: false
+          prerelease: false
+          tag_name: ${{ github.event.client_payload.tag }}
+          files: |
+            ./licenses/BSL.txt
+            ./raw-cli/target/scala-2.12/raw-cli-assembly*.jar

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ on:
   repository_dispatch:
     types: [release]
 jobs:
-  code-checks:
+  create-gh-release:
     runs-on: self-hosted
     container:
       image: ghcr.io/raw-labs/raw-scala-runner:ol8_java17_gvm22.3.0_scala2.12.15_sbt1.6.2
@@ -28,3 +28,14 @@ jobs:
           files: |
             ./licenses/BSL.txt
             ./raw-cli/target/scala-2.12/raw-cli-assembly*.jar
+  notify-main-repo:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v3
+      - name: Notify main repo
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.RAW_CI_PAT }}
+          repository: raw-labs/raw
+          event-type: release
+          client-payload: '{"ref": "${{ github.event.client_payload.ref }}", "tag": "${{ github.event.client_payload.tag }}"}'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,5 +37,5 @@ jobs:
         with:
           token: ${{ secrets.RAW_CI_PAT }}
           repository: raw-labs/raw
-          event-type: release
+          event-type: snapi-release
           client-payload: '{"ref": "${{ github.event.client_payload.ref }}", "tag": "${{ github.event.client_payload.tag }}"}'


### PR DESCRIPTION
This PR implement the following
- RD-9292 create github release after a new tag is pushed
- RD-9190 notify main repo when a new version is published
- RD-9245 build and attach `raw-cli-assembly` jar to the release as an asset
