### PR TITLE
RD-9079: Records with duplicate fields names

### DIFF
--- a/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/builtin/TruffleJsonPackage.scala
+++ b/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/builtin/TruffleJsonPackage.scala
@@ -230,14 +230,11 @@ object JsonRecurse {
         val childRootNode = new ProgramStatementNode(lang, frameDescriptor, child)
         new IterableWriteJsonNode(childRootNode)
       case Rql2RecordType(atts, _) =>
-        val fieldNamesMap = new util.HashMap[String, Integer]
-        val children = atts.zipWithIndex.map {
-          case (att, idx) =>
-            fieldNamesMap.put(att.idn, idx)
-            val child = recurse(att.tipe.asInstanceOf[Rql2TypeWithProperties], isSafe = true)
-            new ProgramStatementNode(lang, frameDescriptor, child)
+        val children = atts.map { att =>
+          val child = recurse(att.tipe.asInstanceOf[Rql2TypeWithProperties], isSafe = true)
+          new ProgramStatementNode(lang, frameDescriptor, child)
         }.toArray
-        new RecordWriteJsonNode(children, fieldNamesMap)
+        new RecordWriteJsonNode(children)
       case Rql2ByteType(_) => new ByteWriteJsonNode()
       case Rql2ShortType(_) => new ShortWriteJsonNode()
       case Rql2IntType(_) => new IntWriteJsonNode()

--- a/raw-compiler-rql2-truffle/src/test/scala/raw/compiler/rql2/tests/regressions/TruffleRegressionTest.scala
+++ b/raw-compiler-rql2-truffle/src/test/scala/raw/compiler/rql2/tests/regressions/TruffleRegressionTest.scala
@@ -40,7 +40,7 @@ import raw.testing.tags.TruffleTests
 @TruffleTests class RD7974TruffleTest extends TruffleCompilerTestContext with RD7974Test
 
 // RD-9079 (duplicate record fields)
-// class RD5714TruffleTest extends TruffleCompilerTestContext with RD5714Test
+@TruffleTests class RD5714TruffleTest extends TruffleCompilerTestContext with RD5714Test
 
 // XML
 // class RD5697TruffleTest extends TruffleCompilerTestContext with RD5697Test
@@ -101,7 +101,7 @@ import raw.testing.tags.TruffleTests
 @TruffleTests class RD5365TruffleTest extends TruffleCompilerTestContext with RD5365Test
 
 // RD-9079 (records with duplicate fields not supported)
-// class RD5914TruffleTest extends TruffleCompilerTestContext with RD5914Test
+@TruffleTests class RD5914TruffleTest extends TruffleCompilerTestContext with RD5914Test
 
 @TruffleTests class RD9137TruffleTest extends TruffleCompilerTestContext with RD9137Test
 @TruffleTests class RD9228TruffleTest extends TruffleCompilerTestContext with RD9228Test

--- a/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/Rql2OutputTestContext.scala
+++ b/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/Rql2OutputTestContext.scala
@@ -114,10 +114,10 @@ trait Rql2OutputTestContext {
         //          }
         //          throw new AssertionError("couldn't parse OrType with any parser")
         case Rql2RecordType(atts, _) if n.isObject =>
-          // TODO (msb): Validate it's the actual type complying with our format
-          val m = mutable.LinkedHashMap[String, Any]()
-          atts.foreach { case Rql2AttrType(idn, t1) => m.put(idn, recurse(n.get(idn), t1)) }
-          m
+          val fields = n.fields().asScala.toVector
+          val tipes = atts.map(_.tipe)
+          assert(fields.length == tipes.length)
+          fields.zip(tipes).map { case (p, t) => p.getKey -> recurse(p.getValue, t) }
         case _: Rql2ListType | _: Rql2IterableType if n.isArray =>
           val inner = t match {
             case Rql2ListType(inner, _) => inner

--- a/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/output/JsonOutputTest.scala
+++ b/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/output/JsonOutputTest.scala
@@ -60,7 +60,6 @@ trait JsonOutputTest extends CompilerTestContext {
     val path: Path = Files.createTempFile("", "")
     try {
       it should saveToInFormat(path, "json")
-      assume(language != "rql2-truffle")
       // fields 'a' are renamed as 'a', 'a_1' and 'a_2'
       path should contain("""{"a":1,"b":2,"a_1":3,"c":4,"a_2":5}""")
     } finally {
@@ -73,7 +72,6 @@ trait JsonOutputTest extends CompilerTestContext {
     val path: Path = Files.createTempFile("", "")
     try {
       it should saveToInFormat(path, "json")
-      assume(language != "rql2-truffle") // duplicated fields not done in rql2-truffle yet
       // fields 'a' are renamed as 'a', 'a_2' because 'a_1' exists already
       path should contain("""{"a":1,"b":2,"a_2":3,"c":4,"a_1":5}""")
     } finally {
@@ -86,7 +84,6 @@ trait JsonOutputTest extends CompilerTestContext {
     val path: Path = Files.createTempFile("", "")
     try {
       it should saveToInFormat(path, "json")
-      assume(language != "rql2-truffle") // duplicated fields not done in rql2-truffle yet
       // fields 'a' are renamed as 'a', 'a_2' because 'a_1' exists already
       path should contain("""{"a_1":1,"b":2,"a":3,"c":4,"a_2":5}""")
     } finally {
@@ -99,7 +96,6 @@ trait JsonOutputTest extends CompilerTestContext {
     val path: Path = Files.createTempFile("", "")
     try {
       it should saveToInFormat(path, "json")
-      assume(language != "rql2-truffle") // duplicated fields not done in rql2-truffle yet
       path should contain("""{"a":1,"b":2,"a_3":3,"c":4,"a_2":5,"a_1":6}""")
     } finally {
       RawUtils.deleteTestPath(path)

--- a/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/regressions/RD3084Test.scala
+++ b/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/regressions/RD3084Test.scala
@@ -36,7 +36,7 @@ trait RD3084Test extends CompilerTestContext with RDBMSTestCreds {
   // switching the order of the fields
   test("""MySQL.Query("mysql-test", "select * from test_types",
     |   type collection(record(char1: string, integer1: int)))""".stripMargin) {
-    _ should evaluateTo("""[{integer1: 1, char1: "string"}]""")
+    _ should evaluateTo("""[{char1: "string", integer1: 1}]""")
   }
 
   test("""PostgreSQL.InferAndQuery("postgres-test", "select * from rdbmstest.test_types")""") {

--- a/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/regressions/RD5714Test.scala
+++ b/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/regressions/RD5714Test.scala
@@ -23,12 +23,7 @@ trait RD5714Test extends CompilerTestContext {
     |    colB = [{id: 2, firstName: "john"}],
     |    join = List.Join(colA, colB, i -> i.name == i.firstName)
     |in Json.Print(join)""".stripMargin) { it =>
-    if (language == "rql2-truffle") {
-      // rql2-truffle fixes duplicated fields as part of RD-9079
-      it should evaluateTo(""" "[{\"id\":1,\"name\":\"john\",\"id\":2,\"firstName\":\"john\"}]" """.stripMargin)
-    } else {
-      it should evaluateTo(""" "[{\"id\":1,\"name\":\"john\",\"id_1\":2,\"firstName\":\"john\"}]" """.stripMargin)
-    }
+    it should evaluateTo(""" "[{\"id\":1,\"name\":\"john\",\"id_1\":2,\"firstName\":\"john\"}]" """.stripMargin)
   }
 
   test("""let colA = [{id: 1, name: "john"}],
@@ -45,11 +40,7 @@ trait RD5714Test extends CompilerTestContext {
         } finally {
           source.close()
         }
-      if (language == "rql2-truffle") {
-        assert(s == """[{"id":1,"name":"john","id":2,"firstName":"john"}]""")
-      } else {
-        assert(s == """[{"id":1,"name":"john","id_1":2,"firstName":"john"}]""")
-      }
+      assert(s == """[{"id":1,"name":"john","id_1":2,"firstName":"john"}]""")
     } finally {
       Files.delete(path)
     }

--- a/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/regressions/RD5914Test.scala
+++ b/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/regressions/RD5914Test.scala
@@ -19,6 +19,8 @@ trait RD5914Test extends CompilerTestContext {
   test("""let item1 = {name: "coffee machine", price: 200, price: 199}, // price is duplicated, price is an int
     |    item2 = {name: "coffee machine", price: 200.00, price: 199.99} // price is duplicated, price is a double
     |in [item1, item2] // item1 integer fields have to be cast to double
-    |""".stripMargin)(_ should run)
+    |""".stripMargin)(_ should evaluateTo("""[{name: "coffee machine", price: 200.0, price: 199.0},
+    |{name: "coffee machine", price: 200.00, price: 199.99}
+    |]""".stripMargin))
 
 }

--- a/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/regressions/RD9228Test.scala
+++ b/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/regressions/RD9228Test.scala
@@ -50,7 +50,7 @@ trait RD9228Test extends CompilerTestContext {
 
   // Declare the location as a variable. Json.Read has to resolve its value dynamically using a walk through frames.
   // Because we read a tryable (list), the tryable handler is involved. It didn't expect the nested read to have a
-  // free variable.
+  // free variable (RD-9329).
   test("""
     |let location = Http.Get("https://raw-tutorial.s3.eu-west-1.amazonaws.com/trips.json")
     |in Json.Read(location, type list(record(

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/RawLanguage.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/RawLanguage.java
@@ -15,7 +15,6 @@ package raw.runtime.truffle;
 import com.oracle.truffle.api.TruffleLanguage;
 import com.oracle.truffle.api.instrumentation.ProvidedTags;
 import com.oracle.truffle.api.instrumentation.StandardTags;
-import com.oracle.truffle.api.object.Shape;
 import com.oracle.truffle.api.nodes.Node;
 import raw.runtime.truffle.runtime.record.RecordObject;
 
@@ -26,12 +25,6 @@ public final class RawLanguage extends TruffleLanguage<RawContext> {
     public static final String ID = "rql";
     public static final String VERSION = "0.10";
     public static final String MIME_TYPE = "application/x-rql";
-
-    private final Shape rootRecordShape;
-
-    public RawLanguage() {
-        this.rootRecordShape = Shape.newBuilder().layout(RecordObject.class).build();
-    }
 
     @Override
     protected final RawContext createContext(Env env) {
@@ -50,11 +43,7 @@ public final class RawLanguage extends TruffleLanguage<RawContext> {
     }
 
     public RecordObject createRecord() {
-        return new RecordObject(rootRecordShape);
-    }
-
-    public RecordObject createRecord(Shape shape) {
-        return new RecordObject(shape);
+        return new RecordObject();
     }
 
 }

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/expressions/record/RecordBuildNode.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/expressions/record/RecordBuildNode.java
@@ -15,14 +15,10 @@ package raw.runtime.truffle.ast.expressions.record;
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.interop.InteropLibrary;
-import com.oracle.truffle.api.interop.UnknownIdentifierException;
-import com.oracle.truffle.api.interop.UnsupportedMessageException;
-import com.oracle.truffle.api.interop.UnsupportedTypeException;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.NodeInfo;
 import raw.runtime.truffle.ExpressionNode;
 import raw.runtime.truffle.RawLanguage;
-import raw.runtime.truffle.runtime.exceptions.RawTruffleInternalErrorException;
 import raw.runtime.truffle.runtime.record.RecordObject;
 
 @NodeInfo(shortName = "Record.Build")
@@ -47,15 +43,11 @@ public class RecordBuildNode extends ExpressionNode {
     @Override
     public RecordObject executeGeneric(VirtualFrame frame) {
         RecordObject record = RawLanguage.get(this).createRecord();
-        try {
-            for (int i = 0, j = 0; i < elementNodes.length; i += 2, j++) {
-                // i jump by 2 because we have k1, v1, k2, v2, ..., kn, vn.
-                Object key = elementNodes[i].executeGeneric(frame);
-                Object value = elementNodes[i + 1].executeGeneric(frame);
-                libraries.writeMember(record, (String) key, value);
-            }
-        } catch (UnknownIdentifierException | UnsupportedMessageException | UnsupportedTypeException e) {
-            throw new RawTruffleInternalErrorException(e, this);
+        for (int i = 0, j = 0; i < elementNodes.length; i += 2, j++) {
+            // i jump by 2 because we have k1, v1, k2, v2, ..., kn, vn.
+            Object key = elementNodes[i].executeGeneric(frame);
+            Object value = elementNodes[i + 1].executeGeneric(frame);
+            record.writeIdx(j, (String) key, value);
         }
         return record;
     }

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/io/csv/reader/parser/RecordParseCsvNode.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/io/csv/reader/parser/RecordParseCsvNode.java
@@ -55,11 +55,7 @@ public class RecordParseCsvNode extends ExpressionNode {
             String fieldName = columns[i].idn();
             parser.getNextField();
             Object value = childDirectCalls[i].call(parser);
-            try {
-                records.writeMember(record, fieldName, value);
-            } catch (UnsupportedMessageException | UnknownIdentifierException | UnsupportedTypeException ex) {
-                throw new RawTruffleInternalErrorException(ex, this);
-            }
+            record.writeIdx(i, fieldName, value);
         }
         parser.finishLine(this);
         return record;

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/runtime/record/RecordStorageObject.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/runtime/record/RecordStorageObject.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 RAW Labs S.A.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0, included in the file
+ * licenses/APL.txt.
+ */
+
+package raw.runtime.truffle.runtime.record;
+
+import com.oracle.truffle.api.object.DynamicObject;
+import com.oracle.truffle.api.object.Shape;
+
+// This is an implementation of `DynamicObject` used as an internal storage of our RecordObject.
+class RecordStorageObject extends DynamicObject {
+
+  protected RecordStorageObject(Shape shape) {
+    super(shape);
+  }
+}


### PR DESCRIPTION
## Main change

The `RecordObject` class has changed:
* values are stored in a `DynamicObject` like they used by stored in, but keys are field _indexes_ instead of field names. That permits to use that class as a storage object without messing up with duplicated keys.
* keys are stored in a `String[]` (possibly duplicated),
* the API write keys takes a key name _and_ an index, that permits to enter duplicated keys.
* the interop API that returns keys (non-duplicated) implements the renaming before returning the list of keys,

The export to JSON is using that API to write a JSON file (since duplicated keys are discouraged by the JSON specs) while certain language nodes (like `Concat`) are using the real keys in order to maintain the proper key names.

The `RecordObject` used to extend `DynamicObject` and have the same API to insert key/values. Here it has a custom API which ideally should be used internally, while using the `Interop` API should be left to external systems. New APIs permit to write keys at a certain index, or for convenience without specifying an index, in which case the 'index++' is used. It also has APIs to read by index (which are now used by nodes that may hit duplicate keys, like `Concat`).

The `RecordObject` still exports the _Interop API_ and several components in the code are accessing it through it. That permits to export it to other Truffle languages. Likely it will be seen as an object with fields that have the keys' names. The `Node` related internal code of _our_ language should use the internal API, so that it can deal with effective field names there's no confusion of which keys are used. This has been done in certain nodes that handle keys in a critical way (`RemoveField`, `Concat`, etc.) but can be implemented in a further patch.

As I was changing the `RecordObject`, I thought since now its usage of a `DynamicObject`  is internal, we can move the boilerplate `Shape` computation to that class.

## Other changes
* `RecordWriteJson` doesn't need the `fieldNameMap` (I think), since fields are written in order of the `RecordType` attributes.
* the `Rql2OutputTestContest` now turns records into sequences of key/values, instead of map. Initially it was to support possible duplicated keys, but they are renamed 