### PR TITLE
RD-9229: data type checks in data exports

### DIFF
--- a/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/builtin/TruffleJsonPackage.scala
+++ b/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/builtin/TruffleJsonPackage.scala
@@ -12,7 +12,9 @@
 
 package raw.compiler.rql2.truffle.builtin
 
+import org.bitbucket.inkytonik.kiama.rewriting.Rewriter._
 import com.oracle.truffle.api.frame.FrameDescriptor
+import org.fusesource.hawtjni.runtime.Library
 import raw.compiler.base.source.Type
 import raw.compiler.rql2.Rql2TypeUtils.removeProp
 import raw.compiler.rql2.builtin.{ParseJsonEntry, PrintJsonEntry, ReadJsonEntry}
@@ -48,14 +50,14 @@ class TruffleReadJsonEntry extends ReadJsonEntry with TruffleEntryExtension {
       case Rql2IterableType(innerType, _) => new JsonReadCollectionNode(
           unnamedArgs.head.e,
           encoding,
-          JsonRecurse
+          JsonIO
             .recurseJsonParser(innerType.asInstanceOf[Rql2TypeWithProperties], dateFormat, timeFormat, timestampFormat)
         )
       case _ =>
         val parseNode = new JsonReadValueNode(
           unnamedArgs.head.e,
           encoding,
-          JsonRecurse
+          JsonIO
             .recurseJsonParser(t.asInstanceOf[Rql2TypeWithProperties], dateFormat, timeFormat, timestampFormat)
         )
         if (t.asInstanceOf[Rql2TypeWithProperties].props.contains(Rql2IsTryableTypeProperty())) {
@@ -82,7 +84,7 @@ class TruffleParseJsonEntry extends ParseJsonEntry with TruffleEntryExtension {
 
     val parseNode = new JsonParseNode(
       unnamedArgs.head.e,
-      JsonRecurse.recurseJsonParser(
+      JsonIO.recurseJsonParser(
         t.asInstanceOf[Rql2TypeWithProperties],
         dateFormat,
         timeFormat,
@@ -100,10 +102,10 @@ class TruffleParseJsonEntry extends ParseJsonEntry with TruffleEntryExtension {
 
 class TrufflePrintJsonEntry extends PrintJsonEntry with TruffleEntryExtension {
   override def toTruffle(t: Type, args: Seq[TruffleArg]): ExpressionNode =
-    new JsonPrintNode(args.head.e, JsonRecurse.recurseJsonWriter(args.head.t.asInstanceOf[Rql2TypeWithProperties]))
+    new JsonPrintNode(args.head.e, JsonIO.recurseJsonWriter(args.head.t.asInstanceOf[Rql2TypeWithProperties]))
 }
 
-object JsonRecurse {
+object JsonIO {
 
   val lang: RawLanguage = RawLanguage.getCurrentContext.getLanguage
   val frameDescriptor = new FrameDescriptor()

--- a/raw-compiler-rql2-truffle/src/test/scala/raw/compiler/rql2/tests/regressions/TruffleRegressionTest.scala
+++ b/raw-compiler-rql2-truffle/src/test/scala/raw/compiler/rql2/tests/regressions/TruffleRegressionTest.scala
@@ -39,7 +39,6 @@ import raw.testing.tags.TruffleTests
 
 @TruffleTests class RD7974TruffleTest extends TruffleCompilerTestContext with RD7974Test
 
-// RD-9079 (duplicate record fields)
 @TruffleTests class RD5714TruffleTest extends TruffleCompilerTestContext with RD5714Test
 
 // XML
@@ -65,8 +64,7 @@ import raw.testing.tags.TruffleTests
 // XML
 // class RD5679TruffleTest extends TruffleCompilerTestContext with RD5679Test
 
-// Runs weird queries that aren't supported by JSON (package entry extensions, functions, etc.) RD-9229 likely
-// @TruffleTests class RD5775TruffleTest extends TruffleCompilerTestContext with RD5775Test
+@TruffleTests class RD5775TruffleTest extends TruffleCompilerTestContext with RD5775Test
 @TruffleTests class RD5851TruffleTest extends TruffleCompilerTestContext with RD5851Test
 
 @TruffleTests class RD5412TruffleTest extends TruffleCompilerTestContext with RD5412Test
@@ -100,11 +98,10 @@ import raw.testing.tags.TruffleTests
 @TruffleTests class RD5685TruffleTest extends TruffleCompilerTestContext with RD5685Test
 @TruffleTests class RD5365TruffleTest extends TruffleCompilerTestContext with RD5365Test
 
-// RD-9079 (records with duplicate fields not supported)
 @TruffleTests class RD5914TruffleTest extends TruffleCompilerTestContext with RD5914Test
 
 @TruffleTests class RD9137TruffleTest extends TruffleCompilerTestContext with RD9137Test
 @TruffleTests class RD9228TruffleTest extends TruffleCompilerTestContext with RD9228Test
-// Fixed by RD-9079
-// @TruffleTests class RD9359TruffleTest extends TruffleCompilerTestContext with RD9359Test
+@TruffleTests class RD9359TruffleTest extends TruffleCompilerTestContext with RD9359Test
 @TruffleTests class RD9255TruffleTest extends TruffleCompilerTestContext with RD9255Test
+@TruffleTests class RD9229TruffleTest extends TruffleCompilerTestContext with RD9229Test

--- a/raw-compiler-rql2-truffle/src/test/scala/raw/compiler/rql2/tests/spec/TruffleSpecTest.scala
+++ b/raw-compiler-rql2-truffle/src/test/scala/raw/compiler/rql2/tests/spec/TruffleSpecTest.scala
@@ -47,9 +47,7 @@ import raw.testing.tags.TruffleTests
 @TruffleTests class BinaryExpPlusTruffleTest extends TruffleCompilerTestContext with BinaryExpPlusTest
 @TruffleTests class BasicStagedCompilerTruffleTest extends TruffleCompilerTestContext with BasicStagedCompilerTest
 @TruffleTests class BinaryExpLtTruffleTest extends TruffleCompilerTestContext with BinaryExpLtTest
-
-// Weird test (perhaps works with RD-9229)
-// class PackageNameTruffleTest extends TruffleCompilerTestContext with PackageNameTest
+@TruffleTests class PackageNameTruffleTest extends TruffleCompilerTestContext with PackageNameTest
 
 // Xml reader
 // class StagedCompilerTruffleTest extends TruffleCompilerTestContext with StagedCompilerTest

--- a/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/SemanticAnalyzer.scala
+++ b/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/SemanticAnalyzer.scala
@@ -719,6 +719,9 @@ class SemanticAnalyzer(val tree: SourceTree.SourceTree)(implicit programContext:
       case (a: TypeAliasType, e: TypeAliasType) => recurse(resolveType(a), resolveType(e))
       case (a: TypeAliasType, _) => recurse(resolveType(a), expected)
       case (_, e: TypeAliasType) => recurse(actual, resolveType(e))
+      case (a: PackageEntryType, e: PackageEntryType) =>
+        if (a.pkgName == e.pkgName && a.entName == e.entName) a else { throw new MergeTypeException }
+      case (a: PackageType, e: PackageType) => if (a.name == e.name) a else { throw new MergeTypeException }
       case (a: PackageType, e: ExpectedProjType) => programContext.getPackage(a.name) match {
           case Some(p) if p.existsEntry(e.i) => actual
           case _ => throw new MergeTypeException

--- a/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/builtin/BinaryPackage.scala
+++ b/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/builtin/BinaryPackage.scala
@@ -12,6 +12,7 @@
 
 package raw.compiler.rql2.builtin
 
+import raw.compiler.base.source.Type
 import raw.compiler.{EntryDoc, ExampleDoc, PackageDoc, ParamDoc, ReturnDoc, TypeDoc}
 import raw.compiler.rql2._
 import raw.compiler.rql2.source._
@@ -24,6 +25,13 @@ class BinaryPackage extends PackageExtension {
     description = "Library of functions for the binary type."
   )
 
+}
+
+object BinaryPackage extends BinaryPackage {
+
+  def outputWriteSupport(dataType: Type): Boolean = {
+    dataType.isInstanceOf[Rql2BinaryType] // nullable/tryable or not. All are supported
+  }
 }
 
 class FromStringBinaryEntryExtension

--- a/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/builtin/CsvPackage.scala
+++ b/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/builtin/CsvPackage.scala
@@ -30,6 +30,44 @@ class CsvPackage extends PackageExtension {
 
 }
 
+object CsvPackage extends CsvPackage {
+
+  def outputWriteSupport(dataType: Type): Boolean = {
+    val innerRecordType = dataType match {
+      case Rql2IterableType(rType: Rql2RecordType, iProps) =>
+        if (iProps.nonEmpty) return false;
+        rType
+      case Rql2ListType(rType: Rql2RecordType, iProps) =>
+        if (iProps.nonEmpty) return false;
+        rType
+    }
+    if (innerRecordType.props.nonEmpty) return false;
+
+    def validColumnType(value: Type): Boolean = {
+      value match {
+        case _: Rql2ByteType => true
+        case _: Rql2ShortType => true
+        case _: Rql2IntType => true
+        case _: Rql2LongType => true
+        case _: Rql2FloatType => true
+        case _: Rql2DoubleType => true
+        case _: Rql2DecimalType => true
+        case _: Rql2StringType => true
+        case _: Rql2BoolType => true
+        case _: Rql2DateType => true
+        case _: Rql2TimeType => true
+        case _: Rql2TimestampType => true
+        case _: Rql2IntervalType => true
+        case _: Rql2BinaryType => true
+        case _ => false
+      }
+    }
+
+    innerRecordType.atts.forall(col => validColumnType(col.tipe))
+  }
+
+}
+
 class CsvInferAndReadEntry extends SugarEntryExtension with CsvEntryExtensionHelper {
 
   override def packageName: String = "Csv"

--- a/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/builtin/JsonPackage.scala
+++ b/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/builtin/JsonPackage.scala
@@ -12,6 +12,7 @@
 
 package raw.compiler.rql2.builtin
 
+import org.bitbucket.inkytonik.kiama.rewriting.Cloner.{everywhere, query}
 import raw.compiler.base.errors.{BaseError, UnsupportedType}
 import raw.compiler.base.source.{AnythingType, BaseNode, Type}
 import raw.compiler.common.source._
@@ -27,6 +28,17 @@ class JsonPackage extends PackageExtension {
   override def docs: PackageDoc = PackageDoc(
     description = "Library of functions for JSON data."
   )
+
+}
+
+object JsonPackage extends JsonPackage {
+
+  def outputWriteSupport(dataType: Type): Boolean = {
+    everywhere(query[Type] {
+      case _: FunType | _: PackageType | _: PackageEntryType | _: Rql2LocationType => return false;
+    })(dataType)
+    true
+  }
 
 }
 

--- a/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/builtin/StringPackage.scala
+++ b/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/builtin/StringPackage.scala
@@ -28,6 +28,13 @@ class StringPackage extends PackageExtension {
 
 }
 
+object StringPackage extends StringPackage {
+
+  def outputWriteSupport(dataType: Type): Boolean = {
+    dataType.isInstanceOf[Rql2StringType] // nullable/tryable or not. All are supported
+  }
+}
+
 class StringFromEntry extends EntryExtension {
 
   override def packageName: String = "String"

--- a/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/regressions/RD9229Test.scala
+++ b/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/regressions/RD9229Test.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 RAW Labs S.A.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0, included in the file
+ * licenses/APL.txt.
+ */
+
+package raw.compiler.rql2.tests.regressions
+
+import raw.compiler.rql2.tests.CompilerTestContext
+
+trait RD9229Test extends CompilerTestContext {
+
+  test(s"""[{a: "binary", b: [1,2,3,4]}]""") { it =>
+    option("output-format", "binary")
+    it should runErrorAs("unsupported type")
+  }
+
+  test(s"""[{a: "text", b: [1,2,3,4]}]""") { it =>
+    option("output-format", "text")
+    it should runErrorAs("unsupported type")
+  }
+
+  test(s"""[{a: "csv", b: [1,2,3,4]}]""") { it =>
+    option("output-format", "csv")
+    it should runErrorAs("unsupported type")
+  }
+
+  test(s"""[{a: (x: int) -> x + 1, b: [1,2,3,4]}]""") { it =>
+    option("output-format", "json")
+    it should runErrorAs("unsupported type")
+  }
+
+  test("\"tralala\"") { it =>
+    option("output-format", "text")
+    it should run
+  }
+
+  test("\"tralala2\"") { it =>
+    option("output-format", "binary")
+    it should runErrorAs("unsupported type")
+  }
+}


### PR DESCRIPTION
This is the patch to make sure a query isn't run when its result should be exported to a format that doesn't support the data type (e.g. records with nested collections when exporting to CSV, but also functions, packages, when exporting to anything).

Related packages `JsonPackage`, `CsvPackage`, `BinaryPackage` and `StringPackage` are exposing an API that checks the target data type and returns true/false depending how it's supported. The `Rql2TruffleCompiler` calls these APIs before building the full tree. Once the tree is built, it's wrapped into the writing nodes. I removed some checks that were performed there since we're checking upfront.

I added a test suite to exercise the change, and some existing tests were enabled.