### PR TITLE
Fixed TextOutputTest assertion

### DIFF
--- a/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/output/TextOutputTest.scala
+++ b/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/output/TextOutputTest.scala
@@ -37,7 +37,7 @@ trait TextOutputTest extends CompilerTestContext {
     try {
       it should saveTo(tmpFile)
     } catch {
-      case e: Exception => assert(e.getMessage == "didn't run due to semantic errors:\nunsupported type")
+      case e: Exception => assert(e.getMessage.contains("unsupported type"))
     } finally {
       Files.delete(tmpFile)
     }


### PR DESCRIPTION
That test is breaking against the Scala executor that reports a slightly different error message. Maybe we can be a little relaxed in the assertion to make both pass? (I tried that one in Scala and it passed.)

The scala failure has both 'unsupported type' and 'expected either common string or option(common string) but got common int'.