### PR TITLE
build: remove unused guava dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -266,7 +266,6 @@ lazy val rawUtils = (project in file("raw-utils"))
     libraryDependencies ++= Seq(
       scalaLogging,
       logbackClassic,
-      guava,
       scalaJava8Compat,
       typesafeConfig,
       loki4jAppender,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -50,8 +50,6 @@ object Dependencies {
 
   val apacheHttpClient = "org.apache.httpcomponents.client5" % "httpclient5" % "5.2.1"
 
-  val guava = "com.google.guava" % "guava" % "32.0.1-jre"
-
   val jacksonDeps = Seq(
     "com.fasterxml.jackson.core" % "jackson-core" % "2.15.2",
     "com.fasterxml.jackson.core" % "jackson-databind" % "2.15.2",


### PR DESCRIPTION
As explained here, we are not using `guava` anymore

https://github.com/raw-labs/snapi/blob/9fada2b665b78cccb1a9dc94b5cd60ffb4de7296/raw-utils/src/main/scala/raw/utils/RawConcurrentHashMap.scala#L22-L24