### PR TITLE
RD-9445 Timestamp json output is different between truffle and scala

### DIFF
--- a/raw-compiler-rql2-truffle/src/test/scala/raw/compiler/rql2/tests/regressions/TruffleRegressionTest.scala
+++ b/raw-compiler-rql2-truffle/src/test/scala/raw/compiler/rql2/tests/regressions/TruffleRegressionTest.scala
@@ -15,6 +15,8 @@ package raw.compiler.rql2.tests.regressions
 import raw.compiler.rql2.tests.TruffleCompilerTestContext
 import raw.testing.tags.TruffleTests
 
+@TruffleTests class RD9445TruffleTest extends TruffleCompilerTestContext with RD9445Test
+
 @TruffleTests class RD5631TruffleTest extends TruffleCompilerTestContext with RD5631Test
 
 @TruffleTests class RD5797TruffleTest extends TruffleCompilerTestContext with RD5797Test

--- a/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/regressions/RD9445Test.scala
+++ b/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/regressions/RD9445Test.scala
@@ -1,0 +1,22 @@
+package raw.compiler.rql2.tests.regressions
+
+import raw.compiler.rql2.tests.CompilerTestContext
+
+import java.nio.file.Files
+import scala.io.Source
+
+trait RD9445Test extends CompilerTestContext {
+
+  test("Timestamp.Build(1975, 6, 23, 9, 0)") { it =>
+    val tmpFile = Files.createTempFile("", "")
+    try {
+      it should saveTo(tmpFile)
+      val s = Source.fromFile(tmpFile.toFile)
+      val lines: List[String] = s.getLines().toList
+      assert(lines == List("1975-23-06T9:00.000"))
+      s.close()
+    } finally {
+      Files.delete(tmpFile)
+    }
+  }
+}

--- a/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/regressions/RD9445Test.scala
+++ b/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/regressions/RD9445Test.scala
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2023 RAW Labs S.A.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0, included in the file
+ * licenses/APL.txt.
+ */
+
 package raw.compiler.rql2.tests.regressions
 
 import org.scalatest.matchers.{MatchResult, Matcher}

--- a/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/regressions/RD9445Test.scala
+++ b/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/regressions/RD9445Test.scala
@@ -1,5 +1,7 @@
 package raw.compiler.rql2.tests.regressions
 
+import org.scalatest.matchers.{MatchResult, Matcher}
+import raw.TestData
 import raw.compiler.rql2.tests.CompilerTestContext
 
 import java.nio.file.Files
@@ -7,16 +9,32 @@ import scala.io.Source
 
 trait RD9445Test extends CompilerTestContext {
 
-  test("Timestamp.Build(1975, 6, 23, 9, 0)") { it =>
-    val tmpFile = Files.createTempFile("", "")
-    try {
-      it should saveTo(tmpFile)
-      val s = Source.fromFile(tmpFile.toFile)
-      val lines: List[String] = s.getLines().toList
-      assert(lines == List("1975-23-06T9:00.000"))
-      s.close()
-    } finally {
-      Files.delete(tmpFile)
+  def outputAs(expected: String, format: String = "json") = new OutputAs(expected, format)
+
+  class OutputAs(expected: String, format: String = "json") extends Matcher[TestData] {
+    def apply(q: TestData): MatchResult = {
+      val tmpFile = Files.createTempFile("", "")
+      try {
+        q should saveToInFormat(tmpFile, format)
+        val s = Source.fromFile(tmpFile.toFile)
+        try {
+          val output = s.getLines().toList.mkString("\n")
+          MatchResult(output == expected, s"Expected '$expected' but got '$output'", "")
+        } finally {
+          s.close()
+        }
+      } finally {
+        Files.delete(tmpFile)
+      }
     }
   }
+
+  test("Timestamp.Build(1975, 6, 23, 9, 0)")(it => it should outputAs(""""1975-06-23T09:00:00.000""""))
+
+  test("Timestamp.Build(1975, 6, 23, 9, 0, millis = 123)")(it => it should outputAs(""""1975-06-23T09:00:00.123""""))
+
+  test("Time.Build(9, 0)")(it => it should outputAs(""""09:00:00.000""""))
+
+  test("Time.Build(9, 0, millis=123)")(it => it should outputAs(""""09:00:00.123""""))
+
 }

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/io/json/writer/JsonWriteNodes.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/io/json/writer/JsonWriteNodes.java
@@ -399,11 +399,7 @@ public final class JsonWriteNodes {
         LocalTime ts = value.getTime();
         // .format throws DateTimeException if its internal StringBuilder throws an IOException.
         // We consider it as an internal error and let it propagate.
-        if (ts.getNano() != 0) {
-          gen.writeString(fmtWithMS.format(ts));
-        } else {
-          gen.writeString(fmtWithoutMS.format(ts));
-        }
+        gen.writeString(fmtWithMS.format(ts));
       } catch (IOException e) {
         throw new JsonWriterRawTruffleException(e.getMessage(), this);
       }

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/io/json/writer/JsonWriteNodes.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/io/json/writer/JsonWriteNodes.java
@@ -356,9 +356,6 @@ public final class JsonWriteNodes {
   @GenerateUncached
   public abstract static class WriteTimestampJsonWriterNode extends Node {
 
-    // two different formatters, depending on whether there are milliseconds or not.
-    private static final DateTimeFormatter fmtWithoutMS =
-        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
     private static final DateTimeFormatter fmtWithMS =
         DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS");
 
@@ -371,11 +368,7 @@ public final class JsonWriteNodes {
         LocalDateTime ts = value.getTimestamp();
         // .format throws DateTimeException if its internal StringBuilder throws an IOException.
         // We consider it as an internal error and let it propagate.
-        if (ts.getNano() != 0) {
-          gen.writeString(fmtWithMS.format(ts));
-        } else {
-          gen.writeString(fmtWithoutMS.format(ts));
-        }
+        gen.writeString(fmtWithMS.format(ts));
       } catch (IOException e) {
         throw new JsonWriterRawTruffleException(e.getMessage(), this);
       }
@@ -388,7 +381,6 @@ public final class JsonWriteNodes {
 
     // two different formatters, depending on whether there are milliseconds or not.
     private static final DateTimeFormatter fmtWithMS = DateTimeFormatter.ofPattern("HH:mm:ss.SSS");
-    private static final DateTimeFormatter fmtWithoutMS = DateTimeFormatter.ofPattern("HH:mm:ss");
 
     public abstract void execute(TimeObject value, JsonGenerator gen);
 


### PR DESCRIPTION
Scala compiler uses just one format string with milliseconds .  So I made the same for truffle.

Quick question:
there was an specific if then else for the case of times/timestamps with milliseconds or not.
Do we prefer this?

Usually its better to have a fixed format but  the format string ` HH:mm:ss[.SSS]` would still parse both cases (with milliseconds and without).

If that is the case I can change the the scala compiler instead