### PR TITLE
RD-9446: Sql.Read/InferAndRead implemented as sugar for .Query

### DIFF
--- a/raw-compiler-rql2-truffle/src/main/resources/META-INF/services/raw.compiler.rql2.EntryExtension
+++ b/raw-compiler-rql2-truffle/src/main/resources/META-INF/services/raw.compiler.rql2.EntryExtension
@@ -121,7 +121,6 @@ raw.compiler.rql2.truffle.builtin.TruffleMathSqrtEntry
 raw.compiler.rql2.truffle.builtin.TruffleMathTanEntry
 raw.compiler.rql2.truffle.builtin.TruffleMathSquareEntry
 raw.compiler.rql2.truffle.builtin.TruffleMathFloorEntry
-raw.compiler.rql2.truffle.builtin.TruffleMySQLReadEntry
 raw.compiler.rql2.truffle.builtin.TruffleMySQLQueryEntry
 raw.compiler.rql2.truffle.builtin.TruffleNullableEmptyEntry
 raw.compiler.rql2.truffle.builtin.TruffleNullableBuildEntry
@@ -129,9 +128,7 @@ raw.compiler.rql2.truffle.builtin.TruffleNullableIsNullEntry
 raw.compiler.rql2.truffle.builtin.TruffleNullableUnsafeGetEntry
 raw.compiler.rql2.truffle.builtin.TruffleNullableTransformEntry
 raw.compiler.rql2.truffle.builtin.TruffleFlatMapNullableTryableEntry
-raw.compiler.rql2.truffle.builtin.TruffleOracleReadEntry
 raw.compiler.rql2.truffle.builtin.TruffleOracleQueryEntry
-raw.compiler.rql2.truffle.builtin.TrufflePostgreSQLReadEntry
 raw.compiler.rql2.truffle.builtin.TrufflePostgreSQLQueryEntry
 raw.compiler.rql2.truffle.builtin.TruffleRecordBuildEntry
 raw.compiler.rql2.truffle.builtin.TruffleRecordConcatEntry
@@ -144,10 +141,8 @@ raw.compiler.rql2.truffle.builtin.TruffleRegexMatchesEntry
 raw.compiler.rql2.truffle.builtin.TruffleRegexFirstMatchInEntry
 raw.compiler.rql2.truffle.builtin.TruffleRegexGroupsEntry
 raw.compiler.rql2.truffle.builtin.TruffleS3BuildEntry
-raw.compiler.rql2.truffle.builtin.TruffleSQLServerReadEntry
 raw.compiler.rql2.truffle.builtin.TruffleSQLServerQueryEntry
 raw.compiler.rql2.truffle.builtin.TruffleShortFromEntry
-raw.compiler.rql2.truffle.builtin.TruffleSnowflakeReadEntry
 raw.compiler.rql2.truffle.builtin.TruffleSnowflakeQueryEntry
 raw.compiler.rql2.truffle.builtin.TruffleStringContainsEntry
 raw.compiler.rql2.truffle.builtin.TruffleStringFromEntry

--- a/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/builtin/TruffleMySQLPackage.scala
+++ b/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/builtin/TruffleMySQLPackage.scala
@@ -13,7 +13,7 @@
 package raw.compiler.rql2.truffle.builtin
 
 import raw.compiler.base.source.Type
-import raw.compiler.rql2.builtin.{MySQLQueryEntry, MySQLReadEntry}
+import raw.compiler.rql2.builtin.MySQLQueryEntry
 import raw.compiler.rql2.source.{Rql2StringType, Rql2TypeWithProperties}
 import raw.compiler.rql2.truffle.{TruffleArg, TruffleEntryExtension}
 import raw.runtime.truffle.ExpressionNode
@@ -22,12 +22,6 @@ import raw.runtime.truffle.ast.expressions.builtin.location_package.LocationBuil
 import raw.runtime.truffle.ast.expressions.literals.StringNode
 import raw.runtime.truffle.runtime.exceptions.rdbms.MySQLExceptionHandler
 import raw.sources.CacheStrategy
-
-class TruffleMySQLReadEntry extends MySQLReadEntry with TruffleEntryExtension {
-
-  override def toTruffle(t: Type, args: Seq[TruffleArg]): ExpressionNode = ???
-
-}
 
 class TruffleMySQLQueryEntry extends MySQLQueryEntry with TruffleEntryExtension {
 

--- a/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/builtin/TruffleOraclePackage.scala
+++ b/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/builtin/TruffleOraclePackage.scala
@@ -13,7 +13,7 @@
 package raw.compiler.rql2.truffle.builtin
 
 import raw.compiler.base.source.Type
-import raw.compiler.rql2.builtin.{OracleQueryEntry, OracleReadEntry}
+import raw.compiler.rql2.builtin.OracleQueryEntry
 import raw.compiler.rql2.source.{Rql2StringType, Rql2TypeWithProperties}
 import raw.compiler.rql2.truffle.{TruffleArg, TruffleEntryExtension}
 import raw.runtime.truffle.ExpressionNode
@@ -22,12 +22,6 @@ import raw.runtime.truffle.ast.expressions.builtin.location_package.LocationBuil
 import raw.runtime.truffle.ast.expressions.literals.StringNode
 import raw.runtime.truffle.runtime.exceptions.rdbms.OracleExceptionHandler
 import raw.sources.CacheStrategy
-
-class TruffleOracleReadEntry extends OracleReadEntry with TruffleEntryExtension {
-
-  override def toTruffle(t: Type, args: Seq[TruffleArg]): ExpressionNode = ???
-
-}
 
 class TruffleOracleQueryEntry extends OracleQueryEntry with TruffleEntryExtension {
 

--- a/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/builtin/TrufflePostgreSQLPackage.scala
+++ b/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/builtin/TrufflePostgreSQLPackage.scala
@@ -13,7 +13,7 @@
 package raw.compiler.rql2.truffle.builtin
 
 import raw.compiler.base.source.Type
-import raw.compiler.rql2.builtin.{PostgreSQLQueryEntry, PostgreSQLReadEntry}
+import raw.compiler.rql2.builtin.PostgreSQLQueryEntry
 import raw.compiler.rql2.source.{Rql2StringType, Rql2TypeWithProperties}
 import raw.compiler.rql2.truffle.{TruffleArg, TruffleEntryExtension}
 import raw.runtime.truffle.ExpressionNode
@@ -23,16 +23,11 @@ import raw.runtime.truffle.ast.expressions.literals.StringNode
 import raw.runtime.truffle.runtime.exceptions.rdbms.PostgreSQLExceptionHandler
 import raw.sources.CacheStrategy
 
-class TrufflePostgreSQLReadEntry extends PostgreSQLReadEntry with TruffleEntryExtension {
-
-  override def toTruffle(t: Type, args: Seq[TruffleArg]): ExpressionNode = ???
-
-}
-
 class TrufflePostgreSQLQueryEntry extends PostgreSQLQueryEntry with TruffleEntryExtension {
 
   override def toTruffle(t: Type, args: Seq[TruffleArg]): ExpressionNode = {
     val db = args.head.e
+    val query = args(1).e
     val optionalArgs = args.collect {
       case TruffleArg(e, _, Some(idn)) => idn match {
           case "host" => ("db-host", e)
@@ -53,6 +48,6 @@ class TrufflePostgreSQLQueryEntry extends PostgreSQLQueryEntry with TruffleEntry
       types.toArray,
       CacheStrategy.NoCache
     )
-    TruffleJdbc.query(location, args(1).e, t, new PostgreSQLExceptionHandler())
+    TruffleJdbc.query(location, query, t, new PostgreSQLExceptionHandler())
   }
 }

--- a/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/builtin/TruffleSQLServerPackage.scala
+++ b/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/builtin/TruffleSQLServerPackage.scala
@@ -13,7 +13,7 @@
 package raw.compiler.rql2.truffle.builtin
 
 import raw.compiler.base.source.Type
-import raw.compiler.rql2.builtin.{SQLServerQueryEntry, SQLServerReadEntry}
+import raw.compiler.rql2.builtin.SQLServerQueryEntry
 import raw.compiler.rql2.source.{Rql2StringType, Rql2TypeWithProperties}
 import raw.compiler.rql2.truffle.{TruffleArg, TruffleEntryExtension}
 import raw.runtime.truffle.ExpressionNode
@@ -22,12 +22,6 @@ import raw.runtime.truffle.ast.expressions.builtin.location_package.LocationBuil
 import raw.runtime.truffle.ast.expressions.literals.StringNode
 import raw.runtime.truffle.runtime.exceptions.rdbms.SqlServerExceptionHandler
 import raw.sources.CacheStrategy
-
-class TruffleSQLServerReadEntry extends SQLServerReadEntry with TruffleEntryExtension {
-
-  override def toTruffle(t: Type, args: Seq[TruffleArg]): ExpressionNode = ???
-
-}
 
 class TruffleSQLServerQueryEntry extends SQLServerQueryEntry with TruffleEntryExtension {
 

--- a/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/builtin/TruffleSnowflakePackage.scala
+++ b/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/builtin/TruffleSnowflakePackage.scala
@@ -13,7 +13,7 @@
 package raw.compiler.rql2.truffle.builtin
 
 import raw.compiler.base.source.Type
-import raw.compiler.rql2.builtin.{SnowflakeQueryEntry, SnowflakeReadEntry}
+import raw.compiler.rql2.builtin.SnowflakeQueryEntry
 import raw.compiler.rql2.source.{Rql2StringType, Rql2TypeWithProperties}
 import raw.compiler.rql2.truffle.{TruffleArg, TruffleEntryExtension}
 import raw.runtime.truffle.ExpressionNode
@@ -22,12 +22,6 @@ import raw.runtime.truffle.ast.expressions.builtin.location_package.LocationBuil
 import raw.runtime.truffle.ast.expressions.literals.StringNode
 import raw.runtime.truffle.runtime.exceptions.rdbms.SnowflakeExceptionHandler
 import raw.sources.CacheStrategy
-
-class TruffleSnowflakeReadEntry extends SnowflakeReadEntry with TruffleEntryExtension {
-
-  override def toTruffle(t: Type, args: Seq[TruffleArg]): ExpressionNode = ???
-
-}
 
 class TruffleSnowflakeQueryEntry extends SnowflakeQueryEntry with TruffleEntryExtension {
 

--- a/raw-compiler-rql2/src/main/resources/META-INF/services/raw.compiler.rql2.EntryExtension
+++ b/raw-compiler-rql2/src/main/resources/META-INF/services/raw.compiler.rql2.EntryExtension
@@ -1,12 +1,17 @@
 raw.compiler.rql2.builtin.MySQLInferAndReadEntry
+raw.compiler.rql2.builtin.MySQLReadEntry
 raw.compiler.rql2.builtin.MySQLInferAndQueryEntry
 raw.compiler.rql2.builtin.OracleInferAndReadEntry
+raw.compiler.rql2.builtin.OracleReadEntry
 raw.compiler.rql2.builtin.OracleInferAndQueryEntry
 raw.compiler.rql2.builtin.PostgreSQLInferAndReadEntry
+raw.compiler.rql2.builtin.PostgreSQLReadEntry
 raw.compiler.rql2.builtin.PostgreSQLInferAndQueryEntry
 raw.compiler.rql2.builtin.SQLServerInferAndReadEntry
+raw.compiler.rql2.builtin.SQLServerReadEntry
 raw.compiler.rql2.builtin.SQLServerInferAndQueryEntry
 raw.compiler.rql2.builtin.SnowflakeInferAndReadEntry
+raw.compiler.rql2.builtin.SnowflakeReadEntry
 raw.compiler.rql2.builtin.SnowflakeInferAndQueryEntry
 raw.compiler.rql2.builtin.CsvInferAndReadEntry
 raw.compiler.rql2.builtin.CsvInferAndParseEntry

--- a/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/builtin/MySQLPackage.scala
+++ b/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/builtin/MySQLPackage.scala
@@ -256,7 +256,9 @@ class MySQLReadEntry extends SugarEntryExtension with SqlTableExtensionHelper {
     val tipe = FunAppArg(TypeExp(mandatoryArgs(2).asInstanceOf[TypeArg].t), None)
     val optArgs = optionalArgs.map { case (idn, ExpArg(e, _)) => FunAppArg(e, Some(idn)) }
 
-    val select = BinaryExp(Plus(), StringConst("SELECT * FROM "), table.e)
+    // MySql needs the table name to be quoted with backticks
+    def quoted(e: Exp) = BinaryExp(Plus(), BinaryExp(Plus(), StringConst("`"), e), StringConst("`"))
+    val select = BinaryExp(Plus(), StringConst("SELECT * FROM "), quoted(table.e))
     val query = FunAppArg(select, None)
     FunApp(
       Proj(PackageIdnExp("MySQL"), "Query"),

--- a/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/builtin/MySQLPackage.scala
+++ b/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/builtin/MySQLPackage.scala
@@ -18,19 +18,23 @@ import raw.compiler.common.source.Exp
 import raw.compiler.rql2.{
   Arg,
   EntryExtension,
+  ExpArg,
   ExpParam,
   PackageExtension,
   Param,
   ProgramContext,
   SugarEntryExtension,
+  TypeArg,
   TypeParam,
   ValueArg,
   ValueParam
 }
 import raw.compiler.rql2.source.{
+  BinaryExp,
   FunApp,
   FunAppArg,
   PackageIdnExp,
+  Plus,
   Proj,
   Rql2IntType,
   Rql2StringType,
@@ -153,7 +157,7 @@ class MySQLInferAndReadEntry extends SugarEntryExtension with SqlTableExtensionH
   }
 }
 
-class MySQLReadEntry extends EntryExtension with SqlTableExtensionHelper {
+class MySQLReadEntry extends SugarEntryExtension with SqlTableExtensionHelper {
 
   override def packageName: String = "MySQL"
 
@@ -240,6 +244,25 @@ class MySQLReadEntry extends EntryExtension with SqlTableExtensionHelper {
     validateTableType(t)
   }
 
+  override def desugar(
+      t: Type,
+      args: Seq[FunAppArg],
+      mandatoryArgs: Seq[Arg],
+      optionalArgs: Seq[(String, Arg)],
+      varArgs: Seq[Arg]
+  )(implicit programContext: ProgramContext): Exp = {
+    val db = FunAppArg(mandatoryArgs.head.asInstanceOf[ExpArg].e, None)
+    val table = FunAppArg(mandatoryArgs(1).asInstanceOf[ExpArg].e, None)
+    val tipe = FunAppArg(TypeExp(mandatoryArgs(2).asInstanceOf[TypeArg].t), None)
+    val optArgs = optionalArgs.map { case (idn, ExpArg(e, _)) => FunAppArg(e, Some(idn)) }
+
+    val select = BinaryExp(Plus(), StringConst("SELECT * FROM "), table.e)
+    val query = FunAppArg(select, None)
+    FunApp(
+      Proj(PackageIdnExp("MySQL"), "Query"),
+      Vector(db, query, tipe) ++ optArgs
+    )
+  }
 }
 
 class MySQLInferAndQueryEntry extends SugarEntryExtension with SqlTableExtensionHelper {

--- a/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/builtin/OraclePackage.scala
+++ b/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/builtin/OraclePackage.scala
@@ -269,6 +269,7 @@ class OracleReadEntry extends SugarEntryExtension with SqlTableExtensionHelper {
     val tipe = FunAppArg(TypeExp(mandatoryArgs(3).asInstanceOf[TypeArg].t), None)
     val optArgs = optionalArgs.map { case (idn, ExpArg(e, _)) => FunAppArg(e, Some(idn)) }
 
+    // Oracle doesn't need the schema and the table to be quoted
     val select = BinaryExp(
       Plus(),
       BinaryExp(Plus(), BinaryExp(Plus(), StringConst("SELECT * FROM "), schema.e), StringConst(".")),

--- a/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/builtin/PostgreSQLPackage.scala
+++ b/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/builtin/PostgreSQLPackage.scala
@@ -248,11 +248,10 @@ class PostgreSQLReadEntry extends SugarEntryExtension with SqlTableExtensionHelp
     val tipe = FunAppArg(TypeExp(mandatoryArgs(3).asInstanceOf[TypeArg].t), None)
     val optArgs = optionalArgs.map { case (idn, ExpArg(e, _)) => FunAppArg(e, Some(idn)) }
 
-    val select = BinaryExp(
-      Plus(),
-      BinaryExp(Plus(), BinaryExp(Plus(), StringConst("SELECT * FROM "), schema.e), StringConst(".")),
-      table.e
-    )
+    // Postgres needs the schema and the table to be quoted
+    def quoted(e: Exp) = BinaryExp(Plus(), BinaryExp(Plus(), StringConst("\""), e), StringConst("\""))
+    val tableRef = BinaryExp(Plus(), BinaryExp(Plus(), quoted(schema.e), StringConst(".")), quoted(table.e))
+    val select = BinaryExp(Plus(), StringConst("SELECT * FROM "), tableRef)
     val query = FunAppArg(select, None)
     FunApp(
       Proj(PackageIdnExp("PostgreSQL"), "Query"),

--- a/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/builtin/SQLServerPackage.scala
+++ b/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/builtin/SQLServerPackage.scala
@@ -249,11 +249,11 @@ class SQLServerReadEntry extends SugarEntryExtension with SqlTableExtensionHelpe
     val tipe = FunAppArg(TypeExp(mandatoryArgs(3).asInstanceOf[TypeArg].t), None)
     val optArgs = optionalArgs.map { case (idn, ExpArg(e, _)) => FunAppArg(e, Some(idn)) }
 
-    val select = BinaryExp(
-      Plus(),
-      BinaryExp(Plus(), BinaryExp(Plus(), StringConst("SELECT * FROM "), schema.e), StringConst(".")),
-      table.e
-    )
+    // SQLServer needs the schema and the table to be quoted
+    def quoted(e: Exp) = BinaryExp(Plus(), BinaryExp(Plus(), StringConst("\""), e), StringConst("\""))
+
+    val tableRef = BinaryExp(Plus(), BinaryExp(Plus(), quoted(schema.e), StringConst(".")), quoted(table.e))
+    val select = BinaryExp(Plus(), StringConst("SELECT * FROM "), tableRef)
     val query = FunAppArg(select, None)
     FunApp(
       Proj(PackageIdnExp("SQLServer"), "Query"),

--- a/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/builtin/SQLServerPackage.scala
+++ b/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/builtin/SQLServerPackage.scala
@@ -140,7 +140,7 @@ class SQLServerInferAndReadEntry extends SugarEntryExtension with SqlTableExtens
   }
 }
 
-class SQLServerReadEntry extends EntryExtension with SqlTableExtensionHelper {
+class SQLServerReadEntry extends SugarEntryExtension with SqlTableExtensionHelper {
 
   override def packageName: String = "SQLServer"
 
@@ -236,6 +236,30 @@ class SQLServerReadEntry extends EntryExtension with SqlTableExtensionHelper {
     validateTableType(t)
   }
 
+  override def desugar(
+      t: Type,
+      args: Seq[FunAppArg],
+      mandatoryArgs: Seq[Arg],
+      optionalArgs: Seq[(String, Arg)],
+      varArgs: Seq[Arg]
+  )(implicit programContext: ProgramContext): Exp = {
+    val db = FunAppArg(mandatoryArgs.head.asInstanceOf[ExpArg].e, None)
+    val schema = FunAppArg(mandatoryArgs(1).asInstanceOf[ExpArg].e, None)
+    val table = FunAppArg(mandatoryArgs(2).asInstanceOf[ExpArg].e, None)
+    val tipe = FunAppArg(TypeExp(mandatoryArgs(3).asInstanceOf[TypeArg].t), None)
+    val optArgs = optionalArgs.map { case (idn, ExpArg(e, _)) => FunAppArg(e, Some(idn)) }
+
+    val select = BinaryExp(
+      Plus(),
+      BinaryExp(Plus(), BinaryExp(Plus(), StringConst("SELECT * FROM "), schema.e), StringConst(".")),
+      table.e
+    )
+    val query = FunAppArg(select, None)
+    FunApp(
+      Proj(PackageIdnExp("SQLServer"), "Query"),
+      Vector(db, query, tipe) ++ optArgs
+    )
+  }
 }
 
 class SQLServerInferAndQueryEntry extends SugarEntryExtension with SqlTableExtensionHelper {

--- a/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/builtin/SnowflakePackage.scala
+++ b/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/builtin/SnowflakePackage.scala
@@ -166,7 +166,7 @@ class SnowflakeInferAndReadEntry extends SugarEntryExtension with SqlTableExtens
   }
 }
 
-class SnowflakeReadEntry extends EntryExtension with SqlTableExtensionHelper {
+class SnowflakeReadEntry extends SugarEntryExtension with SqlTableExtensionHelper {
 
   override def packageName: String = "Snowflake"
 
@@ -249,7 +249,7 @@ class SnowflakeReadEntry extends EntryExtension with SqlTableExtensionHelper {
       case "username" => Right(ExpParam(Rql2StringType()))
       case "password" => Right(ExpParam(Rql2StringType()))
       case "options" => Right(
-          ValueParam(
+          ExpParam(
             Rql2ListType(
               Rql2RecordType(
                 Vector(
@@ -271,6 +271,31 @@ class SnowflakeReadEntry extends EntryExtension with SqlTableExtensionHelper {
   )(implicit programContext: ProgramContext): Either[Seq[BaseError], Type] = {
     val t = mandatoryArgs(3).t
     validateTableType(t)
+  }
+
+  override def desugar(
+      t: Type,
+      args: Seq[FunAppArg],
+      mandatoryArgs: Seq[Arg],
+      optionalArgs: Seq[(String, Arg)],
+      varArgs: Seq[Arg]
+  )(implicit programContext: ProgramContext): Exp = {
+    val db = FunAppArg(mandatoryArgs.head.asInstanceOf[ExpArg].e, None)
+    val schema = FunAppArg(mandatoryArgs(1).asInstanceOf[ExpArg].e, None)
+    val table = FunAppArg(mandatoryArgs(2).asInstanceOf[ExpArg].e, None)
+    val tipe = FunAppArg(TypeExp(mandatoryArgs(3).asInstanceOf[TypeArg].t), None)
+    val optArgs = optionalArgs.map { case (idn, ExpArg(e, _)) => FunAppArg(e, Some(idn)) }
+
+    val select = BinaryExp(
+      Plus(),
+      BinaryExp(Plus(), BinaryExp(Plus(), StringConst("SELECT * FROM "), schema.e), StringConst(".")),
+      table.e
+    )
+    val query = FunAppArg(select, None)
+    FunApp(
+      Proj(PackageIdnExp("Snowflake"), "Query"),
+      Vector(db, query, tipe) ++ optArgs
+    )
   }
 
 }

--- a/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/builtin/MySQLPackageTest.scala
+++ b/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/builtin/MySQLPackageTest.scala
@@ -73,7 +73,6 @@ trait MySQLPackageTest extends CompilerTestContext with RDBMSTestCreds {
   }
 
   test(s"""MySQL.InferAndRead("$mysqlRegDb", "$mysqlTable")""") { it =>
-    assume(language != "rql2-truffle")
     it should evaluateTo(
       """[
         |  {a: 1, b: 1, c: 1.5, d: 1.5, x: "x1", y: "y1"},
@@ -88,7 +87,6 @@ trait MySQLPackageTest extends CompilerTestContext with RDBMSTestCreds {
       |   type collection(record(a: int, b: int, c: double, d: double, x: string, y: string))
       |)""".stripMargin
   ) { it =>
-    assume(language != "rql2-truffle")
     it should evaluateTo(
       """[
         |  {a: 1, b: 1, c: 1.5, d: 1.5, x: "x1", y: "y1"},
@@ -102,7 +100,6 @@ trait MySQLPackageTest extends CompilerTestContext with RDBMSTestCreds {
     s"""MySQL.Read("$mysqlRegDb", "$mysqlTable",
       |   type collection(record(a: int, b: int, c: double, d: double, x: int, y: string)))""".stripMargin
   ) { it =>
-    assume(language != "rql2-truffle")
     it should orderEvaluateTo(
       """[
         |  {a: 1, b: 1, c: 1.5, d: 1.5, x: Error.Build("failed to read value: column 'x': Cannot determine value type from string 'x1'"), y: "y1"},
@@ -116,7 +113,6 @@ trait MySQLPackageTest extends CompilerTestContext with RDBMSTestCreds {
     s"""MySQL.InferAndRead("${mysqlCreds.database}", "$mysqlTable",
       |   host = "${mysqlCreds.host}", username = "${mysqlCreds.username.get.toString}", password = "${mysqlCreds.password.get.toString}")""".stripMargin
   ) { it =>
-    assume(language != "rql2-truffle")
     it should evaluateTo(
       """[
         |  {a: 1, b: 1, c: 1.5, d: 1.5, x: "x1", y: "y1"},
@@ -131,7 +127,6 @@ trait MySQLPackageTest extends CompilerTestContext with RDBMSTestCreds {
       |   type collection(record(a: int, b: int, c: double, d: double, x: int, y: string)),
       |   host = "${mysqlCreds.host}", username = "${mysqlCreds.username.get.toString}", password = "${mysqlCreds.password.get.toString}")""".stripMargin
   ) { it =>
-    assume(language != "rql2-truffle")
     it should orderEvaluateTo(
       """[
         |  {a: 1, b: 1, c: 1.5, d: 1.5, x: Error.Build("failed to read value: column 'x': Cannot determine value type from string 'x1'"), y: "y1"},
@@ -171,10 +166,7 @@ trait MySQLPackageTest extends CompilerTestContext with RDBMSTestCreds {
     s"""MySQL.Read("${mysqlCreds.database}", "$mysqlTable",
       |   type collection(record(a: int, b: int, c: double, d: double, x: int, y: string))
       |)""".stripMargin
-  ) { it =>
-    assume(language != "rql2-truffle")
-    it should runErrorAs(s"""no credential found for mysql: ${mysqlCreds.database}""".stripMargin)
-  }
+  )(it => it should runErrorAs(s"""no credential found for mysql: ${mysqlCreds.database}""".stripMargin))
 
   // server does not exist
   test(
@@ -183,10 +175,7 @@ trait MySQLPackageTest extends CompilerTestContext with RDBMSTestCreds {
       |  type collection(record(a: int, b: int, c: double, d: double, x: int, y: string)),
       |  host = "${badMysqlCreds.host}", username = "${mysqlCreds.username.get.toString}", password = "${mysqlCreds.password.get.toString}"
       |)""".stripMargin
-  ) { it =>
-    assume(language != "rql2-truffle")
-    it should runErrorAs(s"""unknown host: ${badMysqlCreds.host}""".stripMargin)
-  }
+  )(it => it should runErrorAs(s"""unknown host: ${badMysqlCreds.host}""".stripMargin))
 
   // wrong port
   // When there is a wrong port supplied  the test takes a long time to run and we get  an connect time out error.
@@ -196,10 +185,7 @@ trait MySQLPackageTest extends CompilerTestContext with RDBMSTestCreds {
       |  type collection(record(a: int, b: int, c: double, d: double, x: int, y: string)),
       |  host = "${mysqlCreds.host}", username = "${mysqlCreds.username.get.toString}", password = "${mysqlCreds.password.get.toString}", port = 1234
       |)""".stripMargin
-  ) { it =>
-    assume(language != "rql2-truffle")
-    it should runErrorAs(s"""connect timed out: ${mysqlCreds.database}""".stripMargin)
-  }
+  )(it => it should runErrorAs(s"""connect timed out: ${mysqlCreds.database}""".stripMargin))
 
   // No password
   test(
@@ -208,10 +194,7 @@ trait MySQLPackageTest extends CompilerTestContext with RDBMSTestCreds {
       |  type collection(record(a: int, b: int, c: double, d: double, x: int, y: string)),
       |  host = "${mysqlCreds.host}"
       |)""".stripMargin
-  ) { it =>
-    assume(language != "rql2-truffle")
-    it should runErrorAs("""authentication failed""".stripMargin)
-  }
+  )(it => it should runErrorAs("""authentication failed""".stripMargin))
 
   // wrong password
   test(
@@ -220,13 +203,9 @@ trait MySQLPackageTest extends CompilerTestContext with RDBMSTestCreds {
       |  type collection(record(a: int, b: int, c: double, d: double, x: int, y: string)),
       |  host = "${mysqlCreds.host}", username = "${mysqlCreds.username.get.toString}", password = "wrong!"
       |)""".stripMargin
-  ) { it =>
-    assume(language != "rql2-truffle")
-    it should runErrorAs("""authentication failed""".stripMargin)
-  }
+  )(it => it should runErrorAs("""authentication failed""".stripMargin))
 
   test(s"""MySQL.InferAndQuery("$mysqlRegDb", "SELECT * FROM ${mysqlCreds.database}.$mysqlTable")""") { it =>
-    assume(language != "rql2-truffle")
     it should evaluateTo(
       """[
         |  {a: 1, b: 1, c: 1.5, d: 1.5, x: "x1", y: "y1"},
@@ -276,7 +255,6 @@ trait MySQLPackageTest extends CompilerTestContext with RDBMSTestCreds {
   }
 
   test(s"""MySQL.InferAndRead("$mysqlRegDb", "higher_case_columns")""") { it =>
-    assume(language != "rql2-truffle")
     it should evaluateTo(
       """[
         | {ID: 1, Name: "john", Surname: "doe", Address: "123 memory lane"},
@@ -303,7 +281,6 @@ trait MySQLPackageTest extends CompilerTestContext with RDBMSTestCreds {
     |       Surname: string,
     |       Address: string))
     |)""".stripMargin) { it =>
-    assume(language != "rql2-truffle")
     it should evaluateTo(
       """[
         | {ID: 1, Name: "john", Surname: "doe", Address: "123 memory lane"},

--- a/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/builtin/PostgreSQLPackageTest.scala
+++ b/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/builtin/PostgreSQLPackageTest.scala
@@ -73,7 +73,6 @@ trait PostgreSQLPackageTest extends CompilerTestContext with RDBMSTestCreds {
   }
 
   test(s"""PostgreSQL.InferAndRead("pgsql", "$pgSchema", "$pgTable")""") { it =>
-    assume(language != "rql2-truffle")
     it should evaluateTo(
       """[
         |  {a: 1, b: 1, c: 1.5, d: 1.5, x: "x1", y: "y1"},
@@ -88,7 +87,6 @@ trait PostgreSQLPackageTest extends CompilerTestContext with RDBMSTestCreds {
       |   type collection(record(a: int, b: int, c: double, d: double, x: string, y: string))
       |)""".stripMargin
   ) { it =>
-    assume(language != "rql2-truffle")
     it should evaluateTo(
       """[
         |  {a: 1, b: 1, c: 1.5, d: 1.5, x: "x1", y: "y1"},
@@ -102,7 +100,6 @@ trait PostgreSQLPackageTest extends CompilerTestContext with RDBMSTestCreds {
     s"""PostgreSQL.Read("pgsql", "$pgSchema", "$pgTable",
       |   type collection(record(a: int, b: int, c: double, d: double, x: int, y: string)))""".stripMargin
   ) { it =>
-    assume(language != "rql2-truffle")
     it should orderEvaluateTo(
       """[
         |  {a: 1, b: 1, c: 1.5, d: 1.5, x: Error.Build("failed to read value: column 'x': Bad value for type int : x1"), y: "y1"},
@@ -116,7 +113,6 @@ trait PostgreSQLPackageTest extends CompilerTestContext with RDBMSTestCreds {
     s"""PostgreSQL.InferAndRead("${pgsqlCreds.database}", "$pgSchema", "$pgTable",
       |   host = "${pgsqlCreds.host}", username = "${pgsqlCreds.username.get.toString}", password = "${pgsqlCreds.password.get.toString}")""".stripMargin
   ) { it =>
-    assume(language != "rql2-truffle")
     it should evaluateTo(
       """[
         |  {a: 1, b: 1, c: 1.5, d: 1.5, x: "x1", y: "y1"},
@@ -131,7 +127,6 @@ trait PostgreSQLPackageTest extends CompilerTestContext with RDBMSTestCreds {
       |   type collection(record(a: int, b: int, c: double, d: double, x: int, y: string)),
       |   host = "${pgsqlCreds.host}", username = "${pgsqlCreds.username.get.toString}", password = "${pgsqlCreds.password.get.toString}" )""".stripMargin
   ) { it =>
-    assume(language != "rql2-truffle")
     it should orderEvaluateTo(
       """[
         |  {a: 1, b: 1, c: 1.5, d: 1.5, x: Error.Build("failed to read value: column 'x': Bad value for type int : x1"), y: "y1"},
@@ -164,7 +159,6 @@ trait PostgreSQLPackageTest extends CompilerTestContext with RDBMSTestCreds {
   test(
     s"""PostgreSQL.InferAndRead("${pgsqlCreds.database}", "$pgSchema", "$pgTable" )""".stripMargin
   ) { it =>
-    assume(language != "rql2-truffle")
     it should runErrorAs(s"""inference error: no credential found for postgresql: ${pgsqlCreds.database}""".stripMargin)
   }
 
@@ -172,10 +166,7 @@ trait PostgreSQLPackageTest extends CompilerTestContext with RDBMSTestCreds {
     s"""PostgreSQL.Read("${pgsqlCreds.database}", "$pgSchema", "$pgTable",
       |   type collection(record(a: int, b: int, c: double, d: double, x: int, y: string))
       |)""".stripMargin
-  ) { it =>
-    assume(language != "rql2-truffle")
-    it should runErrorAs(s"""no credential found for postgresql: ${pgsqlCreds.database}""".stripMargin)
-  }
+  )(it => it should runErrorAs(s"""no credential found for postgresql: ${pgsqlCreds.database}""".stripMargin))
 
   // server does not exist
   test(
@@ -184,10 +175,7 @@ trait PostgreSQLPackageTest extends CompilerTestContext with RDBMSTestCreds {
       |  type collection(record(a: int, b: int, c: double, d: double, x: int, y: string)),
       |  host = "${badMysqlCreds.host}", username = "${pgsqlCreds.username.get.toString}", password = "${pgsqlCreds.password.get.toString}"
       |)""".stripMargin
-  ) { it =>
-    assume(language != "rql2-truffle")
-    it should runErrorAs(s"""unknown host: ${badMysqlCreds.host}""".stripMargin)
-  }
+  )(it => it should runErrorAs(s"""unknown host: ${badMysqlCreds.host}""".stripMargin))
 
   // wrong port
   // When there is a wrong port supplied  the test takes a long time to run and we get  an connect time out error.
@@ -206,10 +194,7 @@ trait PostgreSQLPackageTest extends CompilerTestContext with RDBMSTestCreds {
       |  type collection(record(a: int, b: int, c: double, d: double, x: int, y: string)),
       |  host = "${pgsqlCreds.host}"
       |)""".stripMargin
-  ) { it =>
-    assume(language != "rql2-truffle")
-    it should runErrorAs(s"""error connecting to database: ${pgsqlCreds.host}""".stripMargin)
-  }
+  )(it => it should runErrorAs(s"""error connecting to database: ${pgsqlCreds.host}""".stripMargin))
 
   // wrong password
   test(
@@ -218,10 +203,7 @@ trait PostgreSQLPackageTest extends CompilerTestContext with RDBMSTestCreds {
       |  type collection(record(a: int, b: int, c: double, d: double, x: int, y: string)),
       |  host = "${pgsqlCreds.host}", username = "${pgsqlCreds.username.get.toString}", password = "wrong!"
       |)""".stripMargin
-  ) { it =>
-    assume(language != "rql2-truffle")
-    it should runErrorAs("""authentication failed""".stripMargin)
-  }
+  )(it => it should runErrorAs("""authentication failed""".stripMargin))
 
   test(s"""PostgreSQL.InferAndQuery("pgsql", "SELECT * FROM $pgSchema.$pgTable")""") { it =>
     it should evaluateTo(

--- a/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/builtin/SnowflakePackageTest.scala
+++ b/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/builtin/SnowflakePackageTest.scala
@@ -85,7 +85,6 @@ trait SnowflakePackageTest extends CompilerTestContext with RDBMSTestCreds {
   property("raw.sources.rdbms.network-timeout", "10s")
 
   test(s"""Snowflake.InferAndRead("snowflake", "$snowflakeSchema", "$snowflakeMainTable")""") { it =>
-    assume(language != "rql2-truffle")
     it should evaluateTo(
       """[
         |  {a: 1, b: 1, c: 1.5, d: 1.5, x: "x1", y: "y1"},
@@ -100,7 +99,6 @@ trait SnowflakePackageTest extends CompilerTestContext with RDBMSTestCreds {
       |   type collection(record(a: int, b: int, c: double, d: double, x: string, y: string))
       |)""".stripMargin
   ) { it =>
-    assume(language != "rql2-truffle")
     it should evaluateTo(
       """[
         |  {a: 1, b: 1, c: 1.5, d: 1.5, x: "x1", y: "y1"},
@@ -116,7 +114,6 @@ trait SnowflakePackageTest extends CompilerTestContext with RDBMSTestCreds {
       |   options = [{"timezone", "UTC"}]
       |)""".stripMargin
   ) { it =>
-    assume(language != "rql2-truffle")
     it should evaluateTo(
       """[
         |  {a: 1, b: 1, c: 1.5, d: 1.5, x: "x1", y: "y1"},
@@ -130,7 +127,6 @@ trait SnowflakePackageTest extends CompilerTestContext with RDBMSTestCreds {
     s"""Snowflake.Read("snowflake", "$snowflakeSchema", "$snowflakeMainTable",
       |   type collection(record(a: int, b: int, c: double, d: double, x: int, y: string)))""".stripMargin
   ) { it =>
-    assume(language != "rql2-truffle")
     it should orderEvaluateTo(
       """[
         |  {a: 1, b: 1, c: 1.5, d: 1.5, x: Error.Build("failed to read value: column 'x': Cannot convert value in the driver from type:TEXT to type:int, value=x1."), y: "y1"},
@@ -141,7 +137,6 @@ trait SnowflakePackageTest extends CompilerTestContext with RDBMSTestCreds {
   }
 
   test(s"""Snowflake.InferAndRead("snowflake", "$snowflakeSchema", "$snowflakeSideTable")""") { it =>
-    assume(language != "rql2-truffle")
     it should evaluateTo(
       """[
         |  {
@@ -190,7 +185,6 @@ trait SnowflakePackageTest extends CompilerTestContext with RDBMSTestCreds {
     |        x: string
     |   ))
     |)""".stripMargin) { it =>
-    assume(language != "rql2-truffle")
     it should evaluateTo(
       """[
         |  {
@@ -231,7 +225,6 @@ trait SnowflakePackageTest extends CompilerTestContext with RDBMSTestCreds {
     s"""Snowflake.InferAndRead("${snowflakeCreds.database}", "$snowflakeSchema", "$snowflakeMainTable",
       |   accountID = "${snowflakeCreds.accountIdentifier}", username = "${snowflakeCreds.username.get.toString}", password = "${snowflakeCreds.password.get.toString}")""".stripMargin
   ) { it =>
-    assume(language != "rql2-truffle")
     it should evaluateTo(
       """[
         |  {a: 1, b: 1, c: 1.5, d: 1.5, x: "x1", y: "y1"},
@@ -246,7 +239,6 @@ trait SnowflakePackageTest extends CompilerTestContext with RDBMSTestCreds {
       |   type collection(record(a: int, b: int, c: double, d: double, x: int, y: string)),
       |   accountID = "${snowflakeCreds.accountIdentifier}", username = "${snowflakeCreds.username.get.toString}", password = "${snowflakeCreds.password.get.toString}" )""".stripMargin
   ) { it =>
-    assume(language != "rql2-truffle")
     it should orderEvaluateTo(
       """[
         |  {a: 1, b: 1, c: 1.5, d: 1.5, x: Error.Build("failed to read value: column 'x': Cannot convert value in the driver from type:TEXT to type:int, value=x1."), y: "y1"},
@@ -288,10 +280,7 @@ trait SnowflakePackageTest extends CompilerTestContext with RDBMSTestCreds {
     s"""Snowflake.Read("${snowflakeCreds.database}", "$snowflakeSchema", "$snowflakeMainTable",
       |   type collection(record(a: int, b: int, c: double, d: double, x: int, y: string))
       |)""".stripMargin
-  ) { it =>
-    assume(language != "rql2-truffle")
-    it should runErrorAs(s"""no credential found for Snowflake: ${snowflakeCreds.database}""".stripMargin)
-  }
+  )(it => it should runErrorAs(s"""no credential found for Snowflake: ${snowflakeCreds.database}""".stripMargin))
 
   // server does not exist
   test(
@@ -301,7 +290,6 @@ trait SnowflakePackageTest extends CompilerTestContext with RDBMSTestCreds {
       |  accountID = "does-not-exist", username = "${snowflakeCreds.username.get.toString}", password = "${snowflakeCreds.password.get.toString}"
       |)""".stripMargin
   ) { it =>
-    assume(language != "rql2-truffle")
     it should runErrorAs(
       """IO error connecting to does-not-exist: JDBC driver encountered communication error. Message: HTTP status=403.""".stripMargin
     )
@@ -314,10 +302,7 @@ trait SnowflakePackageTest extends CompilerTestContext with RDBMSTestCreds {
       |  type collection(record(a: int, b: int, c: double, d: double, x: int, y: string)),
       |  accountID = "${snowflakeCreds.accountIdentifier}"
       |)""".stripMargin
-  ) { it =>
-    assume(language != "rql2-truffle")
-    it should runErrorAs(s"""authentication failed""".stripMargin)
-  }
+  )(it => it should runErrorAs(s"""authentication failed""".stripMargin))
 
   // wrong password
   test(
@@ -327,7 +312,6 @@ trait SnowflakePackageTest extends CompilerTestContext with RDBMSTestCreds {
       |  accountID = "${snowflakeCreds.accountIdentifier}", username = "${snowflakeCreds.username.get.toString}", password = "wrong!"
       |)""".stripMargin
   ) { it =>
-    assume(language != "rql2-truffle")
     it should runErrorAs(
       s"""unable to establish connection to ${snowflakeCreds.accountIdentifier}: Incorrect username or password was specified.""".stripMargin
     )
@@ -390,7 +374,6 @@ trait SnowflakePackageTest extends CompilerTestContext with RDBMSTestCreds {
       |   options = [{"timezone", "America/Los_Angeles"}]
       |)""".stripMargin
   ) { it =>
-    assume(language != "rql2-truffle")
     it should evaluateTo(
       """[
         |  {

--- a/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/builtin/SqlServerPackageTest.scala
+++ b/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/builtin/SqlServerPackageTest.scala
@@ -70,7 +70,6 @@ trait SqlServerPackageTest extends CompilerTestContext with RDBMSTestCreds {
   }
 
   test(s"""SQLServer.InferAndRead("$sqlServRegDb", "$sqlServSchema", "$sqlServTable")""") { it =>
-    assume(language != "rql2-truffle")
     it should evaluateTo(
       """[
         |  {a: 1, b: 1, c: 1.5, d: 1.5, x: "x1", y: "y1"},
@@ -85,7 +84,6 @@ trait SqlServerPackageTest extends CompilerTestContext with RDBMSTestCreds {
       |   type collection(record(a: int, b: int, c: double, d: double, x: string, y: string))
       |)""".stripMargin
   ) { it =>
-    assume(language != "rql2-truffle")
     it should evaluateTo(
       """[
         |  {a: 1, b: 1, c: 1.5, d: 1.5, x: "x1", y: "y1"},
@@ -99,7 +97,6 @@ trait SqlServerPackageTest extends CompilerTestContext with RDBMSTestCreds {
     s"""SQLServer.Read("$sqlServRegDb", "$sqlServSchema", "$sqlServTable",
       |   type collection(record(a: int, b: int, c: double, d: double, x: int, y: string)))""".stripMargin
   ) { it =>
-    assume(language != "rql2-truffle")
     it should orderEvaluateTo(
       """[
         |  {a: 1, b: 1, c: 1.5, d: 1.5, x: Error.Build("failed to read value: column 'x': An error occurred while converting the varchar value to JDBC data type INTEGER."), y: "y1"},
@@ -113,7 +110,6 @@ trait SqlServerPackageTest extends CompilerTestContext with RDBMSTestCreds {
     s"""SQLServer.InferAndRead("$sqlServDb", "$sqlServSchema", "$sqlServTable",
       |   host = "${sqlServerCreds.host}", username = "${sqlServerCreds.username.get.toString}", password = "${sqlServerCreds.password.get.toString}")""".stripMargin
   ) { it =>
-    assume(language != "rql2-truffle")
     it should evaluateTo(
       """[
         |  {a: 1, b: 1, c: 1.5, d: 1.5, x: "x1", y: "y1"},
@@ -128,7 +124,6 @@ trait SqlServerPackageTest extends CompilerTestContext with RDBMSTestCreds {
       |   type collection(record(a: int, b: int, c: double, d: double, x: int, y: string)),
       |   host = "${sqlServerCreds.host}", username = "${sqlServerCreds.username.get.toString}", password = "${sqlServerCreds.password.get.toString}" )""".stripMargin
   ) { it =>
-    assume(language != "rql2-truffle")
     it should orderEvaluateTo(
       """[
         |  {a: 1, b: 1, c: 1.5, d: 1.5, x: Error.Build("failed to read value: column 'x': An error occurred while converting the varchar value to JDBC data type INTEGER."), y: "y1"},
@@ -166,10 +161,7 @@ trait SqlServerPackageTest extends CompilerTestContext with RDBMSTestCreds {
     s"""SQLServer.Read("$sqlServDb", "$sqlServSchema", "$sqlServTable",
       |   type collection(record(a: int, b: int, c: double, d: double, x: int, y: string))
       |)""".stripMargin
-  ) { it =>
-    assume(language != "rql2-truffle")
-    it should runErrorAs(s"""no credential found for sqlserver: $sqlServDb""".stripMargin)
-  }
+  )(it => it should runErrorAs(s"""no credential found for sqlserver: $sqlServDb""".stripMargin))
 
   // server does not exist
   test(
@@ -178,10 +170,7 @@ trait SqlServerPackageTest extends CompilerTestContext with RDBMSTestCreds {
       |  type collection(record(a: int, b: int, c: double, d: double, x: int, y: string)),
       |  host = "does-not-exist", username = "${sqlServerCreds.username.get.toString}", password = "${sqlServerCreds.password.get.toString}"
       |)""".stripMargin
-  ) { it =>
-    assume(language != "rql2-truffle")
-    it should runErrorAs("""error connecting to database: does-not-exist""".stripMargin)
-  }
+  )(it => it should runErrorAs("""error connecting to database: does-not-exist""".stripMargin))
 
   // wrong port
   // When there is a wrong port supplied  the test takes a long time to run and we get  an connect time out error.
@@ -191,10 +180,7 @@ trait SqlServerPackageTest extends CompilerTestContext with RDBMSTestCreds {
       |  type collection(record(a: int, b: int, c: double, d: double, x: int, y: string)),
       |  host = "${sqlServerCreds.host}", username = "${sqlServerCreds.username.get.toString}", password = "${sqlServerCreds.password.get.toString}", port = 1234
       |)""".stripMargin
-  ) { it =>
-    assume(language != "rql2-truffle")
-    it should runErrorAs(s"""connect timed out: ${sqlServerCreds.host}""".stripMargin)
-  }
+  )(it => it should runErrorAs(s"""connect timed out: ${sqlServerCreds.host}""".stripMargin))
 
   // No password
   test(
@@ -203,10 +189,7 @@ trait SqlServerPackageTest extends CompilerTestContext with RDBMSTestCreds {
       |  type collection(record(a: int, b: int, c: double, d: double, x: int, y: string)),
       |  host = "${sqlServerCreds.host}"
       |)""".stripMargin
-  ) { it =>
-    assume(language != "rql2-truffle")
-    it should runErrorAs("""Login failed for user ''""".stripMargin)
-  }
+  )(it => it should runErrorAs("""Login failed for user ''""".stripMargin))
 
   // wrong password
   test(
@@ -215,10 +198,7 @@ trait SqlServerPackageTest extends CompilerTestContext with RDBMSTestCreds {
       |  type collection(record(a: int, b: int, c: double, d: double, x: int, y: string)),
       |  host = "${sqlServerCreds.host}", username = "${sqlServerCreds.username.get.toString}", password = "wrong!"
       |)""".stripMargin
-  ) { it =>
-    assume(language != "rql2-truffle")
-    it should runErrorAs(s"""Login failed for user '${sqlServerCreds.username.get.toString}'""".stripMargin)
-  }
+  )(it => it should runErrorAs(s"""Login failed for user '${sqlServerCreds.username.get.toString}'""".stripMargin))
 
   test(s"""SQLServer.InferAndQuery("$sqlServRegDb", "SELECT * FROM $sqlServSchema.$sqlServTable")""") { it =>
     it should evaluateTo(

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/io/jdbc/JdbcQuery.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/io/jdbc/JdbcQuery.java
@@ -81,132 +81,132 @@ public class JdbcQuery {
   }
 
   @CompilerDirectives.TruffleBoundary
-  byte getByte(String idx, Node node) {
+  byte getByte(String colName, Node node) {
     try {
-      return rs.getByte(idx);
+      return rs.getByte(colName);
     } catch (SQLException e) {
-      throw exceptionHandler.rewrite(e, this, node);
+      throw exceptionHandler.columnParseError(e, colName, node);
     }
   }
 
   @CompilerDirectives.TruffleBoundary
-  short getShort(String idx, Node node) {
+  short getShort(String colName, Node node) {
     try {
-      return rs.getShort(idx);
+      return rs.getShort(colName);
     } catch (SQLException e) {
-      throw exceptionHandler.rewrite(e, this, node);
+      throw exceptionHandler.columnParseError(e, colName, node);
     }
   }
 
   @CompilerDirectives.TruffleBoundary
-  int getInt(String idx, Node node) {
+  int getInt(String colName, Node node) {
     try {
-      return rs.getInt(idx);
+      return rs.getInt(colName);
     } catch (SQLException e) {
-      throw exceptionHandler.rewrite(e, this, node);
+      throw exceptionHandler.columnParseError(e, colName, node);
     }
   }
 
   @CompilerDirectives.TruffleBoundary
-  long getLong(String idx, Node node) {
+  long getLong(String colName, Node node) {
     try {
-      return rs.getLong(idx);
+      return rs.getLong(colName);
     } catch (SQLException e) {
-      throw exceptionHandler.rewrite(e, this, node);
+      throw exceptionHandler.columnParseError(e, colName, node);
     }
   }
 
   @CompilerDirectives.TruffleBoundary
-  float getFloat(String idx, Node node) {
+  float getFloat(String colName, Node node) {
     try {
-      return rs.getFloat(idx);
+      return rs.getFloat(colName);
     } catch (SQLException e) {
-      throw exceptionHandler.rewrite(e, this, node);
+      throw exceptionHandler.columnParseError(e, colName, node);
     }
   }
 
   @CompilerDirectives.TruffleBoundary
-  double getDouble(String idx, Node node) {
+  double getDouble(String colName, Node node) {
     try {
-      return rs.getDouble(idx);
+      return rs.getDouble(colName);
     } catch (SQLException e) {
-      throw exceptionHandler.rewrite(e, this, node);
+      throw exceptionHandler.columnParseError(e, colName, node);
     }
   }
 
   @CompilerDirectives.TruffleBoundary
-  BigDecimal getDecimal(String idx, Node node) {
+  BigDecimal getDecimal(String colName, Node node) {
     try {
-      return rs.getBigDecimal(idx);
+      return rs.getBigDecimal(colName);
     } catch (SQLException e) {
-      throw exceptionHandler.rewrite(e, this, node);
+      throw exceptionHandler.columnParseError(e, colName, node);
     }
   }
 
   @CompilerDirectives.TruffleBoundary
-  String getString(String idx, Node node) {
+  String getString(String colName, Node node) {
     try {
-      return rs.getString(idx);
+      return rs.getString(colName);
     } catch (SQLException e) {
-      throw exceptionHandler.rewrite(e, this, node);
+      throw exceptionHandler.columnParseError(e, colName, node);
     }
   }
 
   @CompilerDirectives.TruffleBoundary
-  boolean getBool(String idx, Node node) {
+  boolean getBool(String colName, Node node) {
     try {
-      return rs.getBoolean(idx);
+      return rs.getBoolean(colName);
     } catch (SQLException e) {
-      throw exceptionHandler.rewrite(e, this, node);
+      throw exceptionHandler.columnParseError(e, colName, node);
     }
   }
 
   @CompilerDirectives.TruffleBoundary
-  DateObject getDate(String idx, Node node) {
+  DateObject getDate(String colName, Node node) {
     try {
-      java.sql.Date sqlDate = rs.getDate(idx);
+      java.sql.Date sqlDate = rs.getDate(colName);
       return new DateObject(sqlDate.toLocalDate());
     } catch (SQLException e) {
-      throw exceptionHandler.rewrite(e, this, node);
+      throw exceptionHandler.columnParseError(e, colName, node);
     }
   }
 
   @CompilerDirectives.TruffleBoundary
-  TimeObject getTime(String idx, Node node) {
+  TimeObject getTime(String colName, Node node) {
     try {
-      java.sql.Time sqlTime = rs.getTime(idx);
+      java.sql.Time sqlTime = rs.getTime(colName);
       return new TimeObject(sqlTime.toLocalTime());
     } catch (SQLException e) {
-      throw exceptionHandler.rewrite(e, this, node);
+      throw exceptionHandler.columnParseError(e, colName, node);
     }
   }
 
   @CompilerDirectives.TruffleBoundary
-  TimestampObject getTimestamp(String idx, Node node) {
+  TimestampObject getTimestamp(String colName, Node node) {
     try {
-      java.sql.Timestamp sqlTimestamp = rs.getTimestamp(idx);
+      java.sql.Timestamp sqlTimestamp = rs.getTimestamp(colName);
       return new TimestampObject(sqlTimestamp.toLocalDateTime());
     } catch (SQLException e) {
-      throw exceptionHandler.rewrite(e, this, node);
+      throw exceptionHandler.columnParseError(e, colName, node);
     }
   }
 
   @CompilerDirectives.TruffleBoundary
-  byte[] getBytes(String idx, Node node) {
+  byte[] getBytes(String colName, Node node) {
     try {
-      return rs.getBytes(idx);
+      return rs.getBytes(colName);
     } catch (SQLException e) {
-      throw exceptionHandler.rewrite(e, this, node);
+      throw exceptionHandler.columnParseError(e, colName, node);
     }
   }
 
   @CompilerDirectives.TruffleBoundary
-  boolean isNull(String idx, Node node) {
+  boolean isNull(String colName, Node node) {
     try {
-      rs.getObject(idx);
+      rs.getObject(colName);
       return rs.wasNull();
     } catch (SQLException e) {
-      throw exceptionHandler.rewrite(e, this, node);
+      throw exceptionHandler.columnParseError(e, colName, node);
     }
   }
 

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/runtime/exceptions/rdbms/JdbcExceptionHandler.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/runtime/exceptions/rdbms/JdbcExceptionHandler.java
@@ -24,6 +24,10 @@ public class JdbcExceptionHandler {
     return new JdbcReaderRawTruffleException(e.getMessage(), rs, e, location);
   }
 
+  public RawTruffleRuntimeException columnParseError(SQLException e, String colName, Node location) {
+    return new JdbcParserRawTruffleException(String.format("column '%s': %s", colName, e.getMessage()), e, location);
+  }
+
   public RawTruffleRuntimeException rewrite(SQLException e, JdbcQuery rs) {
     return new JdbcReaderRawTruffleException(e.getMessage(), rs, e, null);
   }

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/runtime/exceptions/rdbms/JdbcParserRawTruffleException.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/runtime/exceptions/rdbms/JdbcParserRawTruffleException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 RAW Labs S.A.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0, included in the file
+ * licenses/APL.txt.
+ */
+
+package raw.runtime.truffle.runtime.exceptions.rdbms;
+
+import com.oracle.truffle.api.nodes.Node;
+import raw.runtime.truffle.runtime.exceptions.RawTruffleRuntimeException;
+
+public class JdbcParserRawTruffleException extends RawTruffleRuntimeException {
+
+    public JdbcParserRawTruffleException(String message, Throwable e, Node location) {
+        super(String.format("failed to read value: %s", message), e, location);
+    }
+}


### PR DESCRIPTION
Databases `.Read` calls are here implemented as sugar for `.Query`. This patch also impacts the scala executor which I have tested locally. I'll create a release from this branch in order to test Scala in CI.
* existing unimplemented `TruffleRead` nodes have been deleted. Desugaring takes care of the extension now.
* tests were re-enabled.

There are more changes than one would expect. When enabling more tests, some expected failures were exercised and our error message wasn't matching the expected one. The reason being that we didn't distinguish "column errors", hit when trying to decode a certain column as a certain type, from "database errors", hit for example on a connection failure.

Therefore I add a new exception and make sure it's triggered from all the failing column parsers. As part of that change, I renamed `idx` as `colName` since effectively the parameter is a `String` column name.