### PR TITLE
ci: check java fmt + doc gen

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,18 @@ jobs:
       - uses: actions/checkout@v3
       - run: sbt headerCheckAll
       - run: sbt scalafmtCheckAll
+      - run: sbt javafmtCheckAll
+  doc-gen-check:
+    runs-on: self-hosted
+    container:
+      image: ghcr.io/raw-labs/raw-scala-runner:ol8_java17_gvm22.3.0_scala2.12.15_sbt1.6.2
+      options: --user 1001
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.READ_PACKAGES }}
+    steps:
+      - uses: actions/checkout@v3
+      - run: sbt doc
   tests:
     needs: code-checks
     runs-on: self-hosted

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/runtime/exceptions/rdbms/JdbcParserRawTruffleException.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/runtime/exceptions/rdbms/JdbcParserRawTruffleException.java
@@ -17,7 +17,7 @@ import raw.runtime.truffle.runtime.exceptions.RawTruffleRuntimeException;
 
 public class JdbcParserRawTruffleException extends RawTruffleRuntimeException {
 
-    public JdbcParserRawTruffleException(String message, Throwable e, Node location) {
-        super(String.format("failed to read value: %s", message), e, location);
-    }
+  public JdbcParserRawTruffleException(String message, Throwable e, Node location) {
+    super(String.format("failed to read value: %s", message), e, location);
+  }
 }


### PR DESCRIPTION
We integrate a java fmt check and also makes sure we are not breaking the `sbt doc` task.
Since the java formatter can mess with java comments. Like introducing line break after an  `{@link`

- [x] #145 