### PR TITLE
Fixed RD-5910: XML typechecker shouldn't accept complex types for attributes

### DIFF
--- a/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/builtin/XmlPackageTest.scala
+++ b/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/builtin/XmlPackageTest.scala
@@ -642,4 +642,28 @@ trait XmlPackageTest extends CompilerTestContext {
       | Xml.Parse(s, type record(tag: list(byte), notag: list(byte), `#text`: list(byte), `@att`: list(byte)))
       |""".stripMargin
   )(it => it should evaluateTo("{tag: [Byte.From(2)], notag: [], `#text`: [Byte.From(3)], `@att`: [Byte.From(1)]}"))
+
+  // stripping unwanted fields.
+  test(snapi"""Xml.Read("$data", type record(`@place`: string, name: string))""") { it =>
+    it should typeAs("record(`@place`: string, name: string)")
+    it should evaluateTo("{`@place`: \"world\", name: \"john\"}")
+  }
+
+  // lists are accepted when parsing an attribute.
+  test(snapi"""Xml.Read("$data", type record(`@place`: list(string), name: string))""") { it =>
+    it should typeAs("record(`@place`: list(string), name: string)")
+    it should evaluateTo("{`@place`: [\"world\"], name: \"john\"}")
+  }
+
+  // collections are accepted when parsing an attribute.
+  test(snapi"""Xml.Read("$data", type record(`@place`: collection(string), name: string))""") { it =>
+    it should typeAs("record(`@place`: collection(string), name: string)")
+    it should evaluateTo("{`@place`: [\"world\"], name: \"john\"}")
+  }
+
+  // other types than primitives, lists and collections are not accepted when parsing an attribute (RD-5910).
+  test(snapi"""Xml.Read("$data", type record(`@place`: record(a: string), name: string))""") { it =>
+    it should typeErrorAs("unsupported type")
+  }
+
 }

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/runtime/exceptions/rdbms/JdbcParserRawTruffleException.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/runtime/exceptions/rdbms/JdbcParserRawTruffleException.java
@@ -17,7 +17,7 @@ import raw.runtime.truffle.runtime.exceptions.RawTruffleRuntimeException;
 
 public class JdbcParserRawTruffleException extends RawTruffleRuntimeException {
 
-    public JdbcParserRawTruffleException(String message, Throwable e, Node location) {
-        super(String.format("failed to read value: %s", message), e, location);
-    }
+  public JdbcParserRawTruffleException(String message, Throwable e, Node location) {
+    super(String.format("failed to read value: %s", message), e, location);
+  }
 }


### PR DESCRIPTION
The XML typechecker shouldn't accept complex types for attributes. We can cope with `list` and `collection` because those are parsed item by item, and that would lead to lists and collections of one item. Why not. Like for fields. But records no.