### PR TITLE
Fixed RD-5986: Json.Parse/Read shouldn't successfully parse lists and objects are strings

### DIFF
--- a/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/builtin/JsonPackageTest.scala
+++ b/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/builtin/JsonPackageTest.scala
@@ -675,4 +675,8 @@ trait JsonPackageTest extends CompilerTestContext with FailAfterNServer {
     )
   )
 
+  // RD-5986
+  test("""Json.Parse("[10, 9, 8]", type string)""")(_ should runErrorAs("unexpected token: START_ARRAY"))
+  test("""Json.Parse("{\"a\": 12}", type string)""")(_ should runErrorAs("unexpected token: START_OBJECT"))
+
 }

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/io/json/reader/JsonParserNodes.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/io/json/reader/JsonParserNodes.java
@@ -415,7 +415,7 @@ public final class JsonParserNodes {
     String doParse(JsonParser parser) {
       try {
         if (!parser.currentToken().isScalarValue()) {
-          throw new JsonParserRawTruffleException("scalar value found", this);
+          throw new JsonParserRawTruffleException("unexpected token: " + parser.currentToken(), this);
         }
         String v = parser.getText();
         parser.nextToken();


### PR DESCRIPTION
The Truffle parser doesn't have that bug. Maybe the Scala one will need a fix if running that test.

I did add a couple of tests and a better error message (it was wrong: saying "scalar value found" when it shouldn't be "not found"). Anyway the error better states what wasn't expected?