### PR TITLE
RD-9409: Fix the flexible parser (LSP) to accept an extra comma before the `in`

### DIFF
--- a/raw-compiler-rql2-truffle/src/test/scala/raw/compiler/rql2/tests/regressions/TruffleRegressionTest.scala
+++ b/raw-compiler-rql2-truffle/src/test/scala/raw/compiler/rql2/tests/regressions/TruffleRegressionTest.scala
@@ -98,5 +98,6 @@ import raw.testing.tags.TruffleTests
 @TruffleTests class RD9359TruffleTest extends TruffleCompilerTestContext with RD9359Test
 @TruffleTests class RD9255TruffleTest extends TruffleCompilerTestContext with RD9255Test
 @TruffleTests class RD9229TruffleTest extends TruffleCompilerTestContext with RD9229Test
+@TruffleTests class RD9409TruffleTest extends TruffleCompilerTestContext with RD9409Test
 @TruffleTests class RD9479TruffleTest extends TruffleCompilerTestContext with RD9479Test
 @TruffleTests class RD9528TruffleTest extends TruffleCompilerTestContext with RD9528Test

--- a/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/lsp/LspSyntaxAnalyzer.scala
+++ b/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/lsp/LspSyntaxAnalyzer.scala
@@ -87,7 +87,7 @@ class LspSyntaxAnalyzer(positions: Positions) extends FrontendSyntaxAnalyzer(pos
 
   final private lazy val letAttr: Parser[Let] = {
     // Partially written "let", i.e. "in" part missing
-    (tokLet ~> repsep(letDecl, rep1(","))) ~ (opt(tokIn) ~> exp) ^^ { case d ~ e => Let(d, e) }
+    (tokLet ~> repsep(letDecl, rep1(","))) ~ (opt(",") ~> opt(tokIn) ~> exp) ^^ { case d ~ e => Let(d, e) }
   }
 
   // Closing bracket is optional

--- a/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/regressions/RD9409Test.scala
+++ b/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/regressions/RD9409Test.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 RAW Labs S.A.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0, included in the file
+ * licenses/APL.txt.
+ */
+
+package raw.compiler.rql2.tests.regressions
+
+import raw.compiler.rql2.tests.CompilerTestContext
+import raw.compiler.{HoverLSPRequest, HoverLSPResponse, Pos, TypeHoverResponse}
+import raw.runtime.ProgramEnvironment
+
+trait RD9409Test extends CompilerTestContext {
+
+  private val queryEnvironment: ProgramEnvironment = ProgramEnvironment(Some("snapi"), Set.empty, Map.empty)
+
+  test("""// note the extra comma after c = 3
+    |let a = 1,
+    |    b = 2,
+    |    c = 3,
+    |in a + b + c""".stripMargin) { it =>
+    it should parse
+    // now make sure the flexible parser works
+    val code = it.q // this is the query source code
+    // hover on 'a'
+    val HoverLSPResponse(TypeHoverResponse(name, tipe), _) = doLsp(HoverLSPRequest(code, queryEnvironment, Pos(2, 5)))
+    name should be("a")
+    tipe should be("int")
+  }
+
+  test("""// note the extra comma after c: int
+    |let r: record(a: int, b: int, c: int,) = Record.Build(a=1, b=2, c=3)
+    |in r.a + r.b + r.c""".stripMargin) { it =>
+    it should parse
+    // now make sure the flexible parser works
+    val code = it.q // this is the query source code
+    // hover on 'r'
+    val HoverLSPResponse(TypeHoverResponse(name, tipe), _) = doLsp(HoverLSPRequest(code, queryEnvironment, Pos(3, 4)))
+    name should be("r")
+    tipe should be("record(a: int, b: int, c: int)")
+  }
+
+}


### PR DESCRIPTION
The regular inflexible parser is OK with that comma. We should instead accept it in the flexible parser.