### PR TITLE
chore(scala-steward): give us time to upgrade sbt version

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,1 +1,6 @@
 updates.limit = 5
+
+dependencyOverrides = [{
+  pullRequests = { frequency = "30 days" },
+  dependency = { groupId = "org.scala-sbt" }
+}]


### PR DESCRIPTION
Tells scala steward not to spam us with sbt upgrades since we might do it little by little