### PR TITLE
RD-9540: Create fewer inner closures

### DIFF
--- a/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/builtin/TruffleNullableTryablePackage.scala
+++ b/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/builtin/TruffleNullableTryablePackage.scala
@@ -117,10 +117,7 @@ class TruffleFlatMapNullableTryableEntry extends FlatMapNullableTryableEntry wit
             outTypeWithProps.props.contains(Rql2IsNullableTypeProperty()) =>
         OptionFlatMapNodeGen.create(
           emitter.recurseExp(args(0).e),
-          emitter.recurseLambda(() =>
-            new InvokeNode(emitter.recurseExp(args(1).e), Array(null), Array(new ReadParamNode(0)))
-          )
-        )
+          emitter.recurseExp(args(1).e))
     }
   }
 

--- a/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/builtin/TruffleNullableTryablePackage.scala
+++ b/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/builtin/TruffleNullableTryablePackage.scala
@@ -37,26 +37,26 @@ class TruffleFlatMapNullableTryableEntry extends FlatMapNullableTryableEntry wit
       // Case #1. The value is a try+nullable, but only the try needs to be checked (nullable is expected).
       // And the function returns a try+null (likely it is try because of the extra try in the argument).
       // That's kind of a tryable flatMap
-      case (
-            eTypeWithProps: Rql2TypeWithProperties,
-            inTypeWithProps: Rql2TypeWithProperties,
-            outTypeWithProps: Rql2TypeWithProperties
-          )
-          if eTypeWithProps.props == Set(Rql2IsTryableTypeProperty(), Rql2IsNullableTypeProperty()) &&
-            inTypeWithProps.props == Set(Rql2IsNullableTypeProperty()) &&
-            outTypeWithProps.props == Set(Rql2IsTryableTypeProperty(), Rql2IsNullableTypeProperty()) =>
-        ???
-        TryableFlatMapNodeGen.create(
-          emitter.recurseExp(args(0).e),
-          emitter.recurseLambda(() =>
-            new InvokeNode(emitter.recurseExp(args(1).e), Array(null), Array(new ReadParamNode(0)))
-          )
-        )
+//      case (
+//            eTypeWithProps: Rql2TypeWithProperties,
+//            inTypeWithProps: Rql2TypeWithProperties,
+//            outTypeWithProps: Rql2TypeWithProperties
+//          )
+//          if eTypeWithProps.props == Set(Rql2IsTryableTypeProperty(), Rql2IsNullableTypeProperty()) &&
+//            inTypeWithProps.props == Set(Rql2IsNullableTypeProperty()) &&
+//            outTypeWithProps.props == Set(Rql2IsTryableTypeProperty(), Rql2IsNullableTypeProperty()) =>
+//        TryableFlatMapNodeGen.create(
+//          emitter.recurseExp(args(0).e),
+//          emitter.recurseLambda(() =>
+//            new InvokeNode(emitter.recurseExp(args(1).e), Array(null), Array(new ReadParamNode(0)))
+//          )
+//        )
 
       // Case #2. The value is try+nullable, and both properties need to be checked before applying the function.
       // And the function returns a try+nullable. That's kind of a regular flatMap on a tryable+nullable.
       case (eTypeWithProps: Rql2TypeWithProperties, inType, outTypeWithProps: Rql2TypeWithProperties)
           if eTypeWithProps.props == Set(Rql2IsTryableTypeProperty(), Rql2IsNullableTypeProperty()) &&
+            getProps(inType).isEmpty &&
             outTypeWithProps.props == Set(Rql2IsTryableTypeProperty(), Rql2IsNullableTypeProperty()) =>
         TryableFlatMapNodeGen.create(
           emitter.recurseExp(args(0).e),
@@ -64,27 +64,24 @@ class TruffleFlatMapNullableTryableEntry extends FlatMapNullableTryableEntry wit
             OptionGetOrElseNodeGen.create(
               OptionMapNodeGen.create(
                 new ReadParamNode(0),
-                //                wait; this does not evaluate to a function..
-                emitter.recurseLambda(() =>
-                  new InvokeNode(emitter.recurseExp(args(1).e), Array(null), Array(new ReadParamNode(0)))
-                )
+                emitter.recurseExp(args(1).e)
               ),
               TryableSuccessNodeGen.create(new OptionNoneNode(outType))
             )
           )
         )
 
-      // Case #3. No coverage for that one?
-      case (
-            eTypeWithProps: Rql2TypeWithProperties,
-            inTypeWithProps: Rql2TypeWithProperties,
-            outTypeWithProps: Rql2TypeWithProperties
-          )
-          if eTypeWithProps.props == Set(Rql2IsTryableTypeProperty(), Rql2IsNullableTypeProperty()) &&
-            inTypeWithProps.props == Set(Rql2IsNullableTypeProperty()) &&
-            outTypeWithProps.props.contains(Rql2IsNullableTypeProperty()) =>
-        // Not implemented yet!
-        ???
+//      // Case #3. No coverage for that one?
+//      case (
+//            eTypeWithProps: Rql2TypeWithProperties,
+//            inTypeWithProps: Rql2TypeWithProperties,
+//            outTypeWithProps: Rql2TypeWithProperties
+//          )
+//          if eTypeWithProps.props == Set(Rql2IsTryableTypeProperty(), Rql2IsNullableTypeProperty()) &&
+//            inTypeWithProps.props == Set(Rql2IsNullableTypeProperty()) &&
+//            outTypeWithProps.props.contains(Rql2IsNullableTypeProperty()) =>
+//        // Not implemented yet!
+//        ???
 
       // Case #4. The value is a nullable, it's like an option.flatMap BUT the output is a try+nullable.
       // If division is applied to a nullable, that would do that
@@ -94,9 +91,7 @@ class TruffleFlatMapNullableTryableEntry extends FlatMapNullableTryableEntry wit
         OptionGetOrElseNodeGen.create(
           OptionMapNodeGen.create(
             emitter.recurseExp(args(0).e),
-            emitter.recurseLambda(() =>
-              new InvokeNode(emitter.recurseExp(args(1).e), Array(null), Array(new ReadParamNode(0)))
-            )
+            emitter.recurseExp(args(1).e)
           ),
           TryableSuccessNodeGen.create(new OptionNoneNode(outType))
         )

--- a/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/builtin/TruffleNullableTryablePackage.scala
+++ b/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/builtin/TruffleNullableTryablePackage.scala
@@ -21,7 +21,7 @@ import raw.runtime.truffle.ExpressionNode
 import raw.runtime.truffle.ast.expressions.function.InvokeNode
 import raw.runtime.truffle.ast.expressions.option._
 import raw.runtime.truffle.ast.local.ReadParamNode
-import raw.runtime.truffle.ast.expressions.tryable.{TryableFlatMapNodeGen, TryableSuccessNodeGen}
+import raw.runtime.truffle.ast.expressions.tryable.{TryableFlatMapNodeGen, TryableNullableFlatMapNodeGen, TryableSuccessNodeGen}
 import raw.runtime.truffle.ast.expressions.option.{OptionGetOrElseNodeGen, OptionMapNodeGen}
 
 // FlatMapNullableTryableEntry looks like a regular flatMap functionality but it is
@@ -58,17 +58,9 @@ class TruffleFlatMapNullableTryableEntry extends FlatMapNullableTryableEntry wit
           if eTypeWithProps.props == Set(Rql2IsTryableTypeProperty(), Rql2IsNullableTypeProperty()) &&
             getProps(inType).isEmpty &&
             outTypeWithProps.props == Set(Rql2IsTryableTypeProperty(), Rql2IsNullableTypeProperty()) =>
-        TryableFlatMapNodeGen.create(
+        TryableNullableFlatMapNodeGen.create(
           emitter.recurseExp(args(0).e),
-          emitter.recurseLambda(() =>
-            OptionGetOrElseNodeGen.create(
-              OptionMapNodeGen.create(
-                new ReadParamNode(0),
-                emitter.recurseExp(args(1).e)
-              ),
-              TryableSuccessNodeGen.create(new OptionNoneNode(outType))
-            )
-          )
+          emitter.recurseExp(args(1).e)
         )
 
 //      // Case #3. No coverage for that one?

--- a/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/builtin/TruffleNullableTryablePackage.scala
+++ b/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/builtin/TruffleNullableTryablePackage.scala
@@ -18,9 +18,7 @@ import raw.compiler.rql2.builtin.FlatMapNullableTryableEntry
 import raw.compiler.rql2.source._
 import raw.compiler.rql2.truffle.{TruffleEmitter, TruffleEntryExtension}
 import raw.runtime.truffle.ExpressionNode
-import raw.runtime.truffle.ast.expressions.function.InvokeNode
 import raw.runtime.truffle.ast.expressions.option._
-import raw.runtime.truffle.ast.local.ReadParamNode
 import raw.runtime.truffle.ast.expressions.tryable.{TryableFlatMapNodeGen, TryableNullableFlatMapNodeGen, TryableSuccessNodeGen}
 import raw.runtime.truffle.ast.expressions.option.{OptionGetOrElseNodeGen, OptionMapNodeGen}
 

--- a/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/builtin/TruffleNullableTryablePackage.scala
+++ b/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/builtin/TruffleNullableTryablePackage.scala
@@ -106,18 +106,14 @@ class TruffleFlatMapNullableTryableEntry extends FlatMapNullableTryableEntry wit
             outTypeWithProps.props.contains(Rql2IsTryableTypeProperty()) =>
         TryableFlatMapNodeGen.create(
           emitter.recurseExp(args(0).e),
-          emitter.recurseLambda(() =>
-            new InvokeNode(emitter.recurseExp(args(1).e), Array(null), Array(new ReadParamNode(0)))
-          )
+          emitter.recurseExp(args(1).e)
         )
 
       // Case #6 pure option
       case (eTypeWithProps: Rql2TypeWithProperties, inType, outTypeWithProps: Rql2TypeWithProperties)
           if eTypeWithProps.props == Set(Rql2IsNullableTypeProperty()) &&
             outTypeWithProps.props.contains(Rql2IsNullableTypeProperty()) =>
-        OptionFlatMapNodeGen.create(
-          emitter.recurseExp(args(0).e),
-          emitter.recurseExp(args(1).e))
+        OptionFlatMapNodeGen.create(emitter.recurseExp(args(0).e), emitter.recurseExp(args(1).e))
     }
   }
 

--- a/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/builtin/TruffleNullableTryablePackage.scala
+++ b/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/rql2/truffle/builtin/TruffleNullableTryablePackage.scala
@@ -45,6 +45,7 @@ class TruffleFlatMapNullableTryableEntry extends FlatMapNullableTryableEntry wit
           if eTypeWithProps.props == Set(Rql2IsTryableTypeProperty(), Rql2IsNullableTypeProperty()) &&
             inTypeWithProps.props == Set(Rql2IsNullableTypeProperty()) &&
             outTypeWithProps.props == Set(Rql2IsTryableTypeProperty(), Rql2IsNullableTypeProperty()) =>
+        ???
         TryableFlatMapNodeGen.create(
           emitter.recurseExp(args(0).e),
           emitter.recurseLambda(() =>

--- a/raw-compiler-rql2-truffle/src/test/resources/META-INF/services/raw.compiler.rql2.EntryExtension
+++ b/raw-compiler-rql2-truffle/src/test/resources/META-INF/services/raw.compiler.rql2.EntryExtension
@@ -5,6 +5,7 @@ raw.compiler.rql2.tests.builtin.TruffleOptionalValueArgsTestEntry
 raw.compiler.rql2.tests.builtin.TruffleVarExpArgsTestEntry
 raw.compiler.rql2.tests.builtin.TruffleVarValueArgsTestEntry
 raw.compiler.rql2.tests.builtin.TruffleVarNullableStringValueTestEntry
+raw.compiler.rql2.tests.builtin.TruffleVarNullableStringExpTestEntry
 raw.compiler.rql2.tests.builtin.TruffleStrictArgsTestEntry
 raw.compiler.rql2.tests.builtin.TruffleStrictArgsColPassThroughTestEntry
 raw.compiler.rql2.tests.builtin.TruffleByteValueArgTestEntry

--- a/raw-compiler-rql2-truffle/src/test/scala/raw/compiler/rql2/tests/builtin/TruffleTestPackage.scala
+++ b/raw-compiler-rql2-truffle/src/test/scala/raw/compiler/rql2/tests/builtin/TruffleTestPackage.scala
@@ -75,6 +75,14 @@ class TruffleVarNullableStringValueTestEntry extends VarNullableStringValueTestE
   }
 
 }
+
+class TruffleVarNullableStringExpTestEntry extends VarNullableStringExpTestEntry with TruffleEntryExtension {
+  override def toTruffle(t: Type, args: Seq[TruffleArg]): ExpressionNode = {
+    args(0).e
+  }
+
+}
+
 class TruffleStrictArgsTestEntry extends StrictArgsTestEntry with TruffleEntryExtension {
   override def toTruffle(t: Type, args: Seq[TruffleArg]): ExpressionNode = {
     val listArg = args(0).e

--- a/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/Propagation.scala
+++ b/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/Propagation.scala
@@ -350,7 +350,7 @@ class Propagation(protected val parent: Phase[SourceProgram], protected val phas
     case StringValue(v) => StringConst(v)
     case BoolValue(v) => BoolConst(v)
     case OptionValue(option) =>
-      val innerType = removeProp(t, Rql2IsNullableTypeProperty())
+      val innerType = resetProps(t, Set.empty)
       option
         .map(v => valueToExp(v, innerType))
         .map(NullablePackageBuilder.Build(_))

--- a/raw-compiler-rql2/src/test/resources/META-INF/services/raw.compiler.rql2.EntryExtension
+++ b/raw-compiler-rql2/src/test/resources/META-INF/services/raw.compiler.rql2.EntryExtension
@@ -5,6 +5,7 @@ raw.compiler.rql2.tests.builtin.OptionalValueArgsTestEntry
 raw.compiler.rql2.tests.builtin.VarExpArgsTestEntry
 raw.compiler.rql2.tests.builtin.VarValueArgsTestEntry
 raw.compiler.rql2.tests.builtin.VarNullableStringValueTestEntry
+raw.compiler.rql2.tests.builtin.VarNullableStringExpTestEntry
 raw.compiler.rql2.tests.builtin.StrictArgsTestEntry
 raw.compiler.rql2.tests.builtin.StrictArgsColPassThroughTestEntry
 raw.compiler.rql2.tests.builtin.StrictArgsColConsumeTestEntry

--- a/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/builtin/TestPackage.scala
+++ b/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/builtin/TestPackage.scala
@@ -172,10 +172,10 @@ class VarNullableStringExpTestEntry extends EntryExtension {
     Right(ExpParam(Rql2StringType(Set(Rql2IsNullableTypeProperty()))))
 
   override def returnType(
-                           mandatoryArgs: Seq[Arg],
-                           optionalArgs: Seq[(String, Arg)],
-                           varArgs: Seq[Arg]
-                         )(implicit programContext: ProgramContext): Either[String, Type] = {
+      mandatoryArgs: Seq[Arg],
+      optionalArgs: Seq[(String, Arg)],
+      varArgs: Seq[Arg]
+  )(implicit programContext: ProgramContext): Either[String, Type] = {
     Right(Rql2StringType(Set(Rql2IsNullableTypeProperty())))
   }
 

--- a/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/builtin/TestPackage.scala
+++ b/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/builtin/TestPackage.scala
@@ -156,6 +156,31 @@ class VarNullableStringValueTestEntry extends EntryExtension {
 
 }
 
+class VarNullableStringExpTestEntry extends EntryExtension {
+
+  override def packageName: String = "TestPackage"
+
+  override def entryName: String = "VarExpNullableStringArgs"
+
+  override def docs: EntryDoc = ???
+
+  override def nrMandatoryParams: Int = 0
+
+  override def hasVarArgs: Boolean = true
+
+  override def getVarParam(prevMandatoryArgs: Seq[Arg], prevVarArgs: Seq[Arg], idx: Int): Either[String, Param] =
+    Right(ExpParam(Rql2StringType(Set(Rql2IsNullableTypeProperty()))))
+
+  override def returnType(
+                           mandatoryArgs: Seq[Arg],
+                           optionalArgs: Seq[(String, Arg)],
+                           varArgs: Seq[Arg]
+                         )(implicit programContext: ProgramContext): Either[String, Type] = {
+    Right(Rql2StringType(Set(Rql2IsNullableTypeProperty())))
+  }
+
+}
+
 class StrictArgsTestEntry extends EntryExtension {
 
   override def packageName: String = "TestPackage"

--- a/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/spec/PropagationTest.scala
+++ b/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/spec/PropagationTest.scala
@@ -15,7 +15,9 @@ package raw.compiler.rql2.tests.spec
 import raw.compiler.rql2.tests.CompilerTestContext
 
 trait PropagationTest extends CompilerTestContext {
-
+  test("""let n: string = null in List.First(["a", "b", n])""")(_ should evaluateTo("\"a\""))
+  test("""let n: string = null in TestPackage.VarValueNullableStringArgs("a", "b", n)""")(_ should evaluateTo("\"ab\""))
+  test("""let n: string = null in TestPackage.VarExpNullableStringArgs("a", "b", n)""")(_ should evaluateTo("\"a\""))
   // lists
   test("""let l = List.Build(1,2,3,2,1)
     |in TestPackage.StrictArgs(l)""".stripMargin)(_ should (typeAs("float") and evaluateTo("5.0f")))

--- a/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/spec/PropagationTest.scala
+++ b/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/spec/PropagationTest.scala
@@ -15,9 +15,6 @@ package raw.compiler.rql2.tests.spec
 import raw.compiler.rql2.tests.CompilerTestContext
 
 trait PropagationTest extends CompilerTestContext {
-  test("""let n: string = null in List.First(["a", "b", n])""")(_ should evaluateTo("\"a\""))
-  test("""let n: string = null in TestPackage.VarValueNullableStringArgs("a", "b", n)""")(_ should evaluateTo("\"ab\""))
-  test("""let n: string = null in TestPackage.VarExpNullableStringArgs("a", "b", n)""")(_ should evaluateTo("\"a\""))
   // lists
   test("""let l = List.Build(1,2,3,2,1)
     |in TestPackage.StrictArgs(l)""".stripMargin)(_ should (typeAs("float") and evaluateTo("5.0f")))
@@ -421,4 +418,7 @@ trait PropagationTest extends CompilerTestContext {
   test("""TestPackage.VarValueNullableStringArgs("a", Error.Build("argh!"), "c")""")(_ should runErrorAs("argh!"))
   test("""TestPackage.VarValueNullableStringArgs(Error.Build("argh!"), "b", "c")""")(_ should runErrorAs("argh!"))
 
+  test("""let n: string = null in List.First(["a", "b", n])""")(_ should evaluateTo("\"a\""))
+  test("""let n: string = null in TestPackage.VarValueNullableStringArgs("a", "b", n)""")(_ should evaluateTo("\"ab\""))
+  test("""let n: string = null in TestPackage.VarExpNullableStringArgs("a", "b", n)""")(_ should evaluateTo("\"a\""))
 }

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/expressions/tryable/TryableNullableFlatMapNode.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/expressions/tryable/TryableNullableFlatMapNode.java
@@ -28,25 +28,26 @@ import raw.runtime.truffle.runtime.tryable.TryableLibrary;
 @NodeChild("function")
 public abstract class TryableNullableFlatMapNode extends ExpressionNode {
 
-    private final Object[] argumentValues = new Object[1];
-    private final ObjectTryable successNone = ObjectTryable.BuildSuccess(new EmptyOption());
+  private final Object[] argumentValues = new Object[1];
+  private final ObjectTryable successNone = ObjectTryable.BuildSuccess(new EmptyOption());
 
-    @Specialization(limit = "1")
-    protected Object doTryable(
-        Object tryable, Closure closure,
-        @CachedLibrary("tryable") TryableLibrary tryables,
-        @CachedLibrary(limit = "1") OptionLibrary nullables) {
-        if (tryables.isSuccess(tryable)) {
-            Object n = tryables.success(tryable);
-            if (nullables.isDefined(n)) {
-                Object v = nullables.get(n);
-                argumentValues[0] = v;
-                return closure.call(argumentValues);
-            } else {
-                return successNone;
-            }
-        } else {
-            return tryable;
-        }
+  @Specialization(limit = "1")
+  protected Object doTryable(
+      Object tryable,
+      Closure closure,
+      @CachedLibrary("tryable") TryableLibrary tryables,
+      @CachedLibrary(limit = "1") OptionLibrary nullables) {
+    if (tryables.isSuccess(tryable)) {
+      Object n = tryables.success(tryable);
+      if (nullables.isDefined(n)) {
+        Object v = nullables.get(n);
+        argumentValues[0] = v;
+        return closure.call(argumentValues);
+      } else {
+        return successNone;
+      }
+    } else {
+      return tryable;
     }
+  }
 }

--- a/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/expressions/tryable/TryableNullableFlatMapNode.java
+++ b/raw-runtime-rql2-truffle/src/main/java/raw/runtime/truffle/ast/expressions/tryable/TryableNullableFlatMapNode.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 RAW Labs S.A.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0, included in the file
+ * licenses/APL.txt.
+ */
+
+package raw.runtime.truffle.ast.expressions.tryable;
+
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.library.CachedLibrary;
+import com.oracle.truffle.api.nodes.NodeInfo;
+import raw.runtime.truffle.ExpressionNode;
+import raw.runtime.truffle.runtime.function.Closure;
+import raw.runtime.truffle.runtime.option.EmptyOption;
+import raw.runtime.truffle.runtime.option.OptionLibrary;
+import raw.runtime.truffle.runtime.tryable.ObjectTryable;
+import raw.runtime.truffle.runtime.tryable.TryableLibrary;
+
+@NodeInfo(shortName = "TryableNullable.FlatMap")
+@NodeChild("tryable")
+@NodeChild("function")
+public abstract class TryableNullableFlatMapNode extends ExpressionNode {
+
+    private final Object[] argumentValues = new Object[1];
+    private final ObjectTryable successNone = ObjectTryable.BuildSuccess(new EmptyOption());
+
+    @Specialization(limit = "1")
+    protected Object doTryable(
+        Object tryable, Closure closure,
+        @CachedLibrary("tryable") TryableLibrary tryables,
+        @CachedLibrary(limit = "1") OptionLibrary nullables) {
+        if (tryables.isSuccess(tryable)) {
+            Object n = tryables.success(tryable);
+            if (nullables.isDefined(n)) {
+                Object v = nullables.get(n);
+                argumentValues[0] = v;
+                return closure.call(argumentValues);
+            } else {
+                return successNone;
+            }
+        } else {
+            return tryable;
+        }
+    }
+}


### PR DESCRIPTION
While trying to trigger certain code paths in `TruffleNullableTryablePackage` with new test cases in `PropagationTest`, I hit an unrelated bug. Hence the new tests, the new `TestPackage` code and the fix in `Propagation`.

I noticed several of the `toTruffle` paths in the `FlatMap` node were having an extra `Closure`, as if we'd create a tree with:
```
\x -> f(x)
```
which is equivalent to `f` itself. Removing those is a safe fix and it improves performance.

I tried to get rid of all calls to `recurseLambda`. This led me to implement a new truffle `Node` that protects both the tryable _and_ the nullable sides of a value. It's used a lot since as soon as a user types a type, it's both tryable and nullable.