### PR TITLE
RD-9529 Add code cache

### DIFF
--- a/raw-compiler-rql2-truffle/src/main/resources/reference.conf
+++ b/raw-compiler-rql2-truffle/src/main/resources/reference.conf
@@ -1,0 +1,5 @@
+raw.compiler.truffle {
+    code-cache {
+        expire-after-access = 1h
+    }
+}

--- a/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/truffle/TruffleCompiler.scala
+++ b/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/truffle/TruffleCompiler.scala
@@ -55,9 +55,10 @@ class TruffleProgramOutputWriter(entrypoint: TruffleEntrypoint)(
       }
     } finally {
       // We explicitly created and then entered the context during code emission.
-      // Now we explicitly leave and close the context.
+      // Now we explicitly leave the context.
       entrypoint.context.leave()
-     // entrypoint.context.close()
+      // The context is NOT closed because the entrypoint is in the code cache;
+      // it will be removed when the entrypoint is removed from the cache.
     }
   }
 }

--- a/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/truffle/TruffleCompiler.scala
+++ b/raw-compiler-rql2-truffle/src/main/scala/raw/compiler/truffle/TruffleCompiler.scala
@@ -57,7 +57,7 @@ class TruffleProgramOutputWriter(entrypoint: TruffleEntrypoint)(
       // We explicitly created and then entered the context during code emission.
       // Now we explicitly leave and close the context.
       entrypoint.context.leave()
-      entrypoint.context.close()
+     // entrypoint.context.close()
     }
   }
 }

--- a/raw-compiler/src/main/resources/reference.conf
+++ b/raw-compiler/src/main/resources/reference.conf
@@ -10,9 +10,6 @@ raw {
         # Time after which an inferrer cache entry expires if it is not accessed!
         expiry = 30s
     }
-    code-cache {
-        size = 10000
-    }
     output-format = "hjson"
     windows-line-ending = false
     skip-phases = []

--- a/raw-compiler/src/main/resources/reference.conf
+++ b/raw-compiler/src/main/resources/reference.conf
@@ -10,6 +10,9 @@ raw {
         # Time after which an inferrer cache entry expires if it is not accessed!
         expiry = 30s
     }
+    code-cache {
+        size = 10000
+    }
     output-format = "hjson"
     windows-line-ending = false
     skip-phases = []


### PR DESCRIPTION
(Work-in-progress.)

The code cache is a cache of Truffle entrypoints, which then allows us to re-use the emitter code.

However, there are multiple caveats to this particular implementation.

The first is handling the context. The context is created during code emission, and it is closed when we are "done"with the query. That said, we don't know when we are done with the query - it can take a while to execute. The cache tries to handle that by expiring entries after access: if we only remove queries that have not been used recently, then this means we should not be removing queries that are still executing. It's a compromise solution. Also, that's why we don't have a max size for the cache - this could more easily trigger the removal of an entrypoint from the cache while it is still executing.

We are also using CacheBuilder.get(..., orElse) pattern, which isn't as safe as the builder pattern. That said, we cannot use the builder pattern because the ProgramContext would not be available in the constructor.

So all in all, this cache is not ideal but it should work in most common scenarios. It is a proposal and can be re-visited in the future, when we move to using the Context correctly.