### PR TITLE
Fixing documentation of rdbms

### DIFF
--- a/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/builtin/MySQLPackage.scala
+++ b/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/builtin/MySQLPackage.scala
@@ -164,7 +164,7 @@ class MySQLReadEntry extends SugarEntryExtension with SqlTableExtensionHelper {
   override def entryName: String = "Read"
 
   override def docs: EntryDoc = EntryDoc(
-    "Reads a MySQL table with schema detection (inference).",
+    "Reads a MySQL table.",
     params = List(
       ParamDoc(
         "database",

--- a/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/builtin/OraclePackage.scala
+++ b/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/builtin/OraclePackage.scala
@@ -170,7 +170,7 @@ class OracleReadEntry extends SugarEntryExtension with SqlTableExtensionHelper {
   override def entryName: String = "Read"
 
   override def docs: EntryDoc = EntryDoc(
-    "Reads a Oracle table with schema detection (inference).",
+    "Reads a Oracle table.",
     params = List(
       ParamDoc(
         "database",

--- a/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/builtin/PostgreSQLPackage.scala
+++ b/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/builtin/PostgreSQLPackage.scala
@@ -146,7 +146,7 @@ class PostgreSQLReadEntry extends SugarEntryExtension with SqlTableExtensionHelp
   override def entryName: String = "Read"
 
   override def docs: EntryDoc = EntryDoc(
-    "Reads a PostgreSQL table with schema detection (inference).",
+    "Reads a PostgreSQL table.",
     params = List(
       ParamDoc(
         "database",

--- a/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/builtin/SQLServerPackage.scala
+++ b/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/builtin/SQLServerPackage.scala
@@ -147,7 +147,7 @@ class SQLServerReadEntry extends SugarEntryExtension with SqlTableExtensionHelpe
   override def entryName: String = "Read"
 
   override def docs: EntryDoc = EntryDoc(
-    "Reads a SQLServer table with schema detection (inference).",
+    "Reads a SQLServer table.",
     params = List(
       ParamDoc(
         "database",

--- a/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/builtin/SnowflakePackage.scala
+++ b/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/builtin/SnowflakePackage.scala
@@ -173,7 +173,7 @@ class SnowflakeReadEntry extends SugarEntryExtension with SqlTableExtensionHelpe
   override def entryName: String = "Read"
 
   override def docs: EntryDoc = EntryDoc(
-    "Reads a Snowflake table with schema detection (inference).",
+    "Reads a Snowflake table.",
     params = List(
       ParamDoc(
         "database",


### PR DESCRIPTION
There is a copy paste mistake for the databases `Read` documentation.
They have the same explanations as the `InferAndRead` entry.
