### PR TITLE
RD-9598: Missing error case in Errors.PrettyPrinter

### DIFF
--- a/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/errors/ErrorsPrettyPrinter.scala
+++ b/raw-compiler-rql2/src/main/scala/raw/compiler/rql2/errors/ErrorsPrettyPrinter.scala
@@ -25,6 +25,7 @@ trait ErrorsPrettyPrinter extends common.errors.ErrorsPrettyPrinter with rql2.so
     case _: CannotDetermineTypeOfParameter => CannotDetermineTypeOfParameter.message
     case _: OutputTypeRequiredForRecursiveFunction => OutputTypeRequiredForRecursiveFunction.message
     case InvalidOrderSpec(_, spec) => InvalidOrderSpec.message <> colon <+> spec
+    case _: OrderSpecMustFollowOrderingFunction => OrderSpecMustFollowOrderingFunction.message
     case _: PackageNotFound => PackageNotFound.message
     case _: NamedParameterAfterOptionalParameter => NamedParameterAfterOptionalParameter.message
     case _: InvalidType => InvalidType.message

--- a/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/builtin/collection/CollectionOrderByTest.scala
+++ b/raw-compiler-rql2/src/test/scala/raw/compiler/rql2/tests/builtin/collection/CollectionOrderByTest.scala
@@ -13,7 +13,12 @@
 package raw.compiler.rql2.tests.builtin.collection
 
 import raw.compiler.SnapiInterpolator
-import raw.compiler.rql2.errors.{InvalidOrderSpec, KeyNotComparable}
+import raw.compiler.rql2.errors.{
+  InvalidOrderSpec,
+  ItemsNotComparable,
+  KeyNotComparable,
+  OrderSpecMustFollowOrderingFunction
+}
 import raw.compiler.rql2.tests.CompilerTestContext
 import raw.sources.filesystem.local.LocalLocationsTestContext
 
@@ -313,6 +318,10 @@ trait CollectionOrderByTest extends CompilerTestContext with LocalLocationsTestC
 
   test("""Collection.OrderBy(Collection.Build(1,2,3), n -> n * 10, "BIM",  n -> n / 2, "BOUM")""")(
     _ should runErrorAs(InvalidOrderSpec.message)
+  )
+
+  test("""Collection.OrderBy(Collection.Build(1,2,3), n -> n * 10, "ASC",  n -> n / 2)""")(
+    _ should runErrorAs(OrderSpecMustFollowOrderingFunction.message)
   )
 
 }


### PR DESCRIPTION
Added a test to trigger the bug and the fix.

I also walked through all errors and ensured they're referenced in `ErrorsPrettyPrinter`.