### PR TITLE
RD-9616: Fix the computation of Interval.ToMillis

### DIFF
--- a/snapi-client/src/test/scala/raw/compiler/rql2/tests/regressions/RD9616Test.scala
+++ b/snapi-client/src/test/scala/raw/compiler/rql2/tests/regressions/RD9616Test.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 RAW Labs S.A.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0, included in the file
+ * licenses/APL.txt.
+ */
+
+package raw.compiler.rql2.tests.regressions
+
+import raw.compiler.rql2.tests.CompilerTestContext
+
+trait RD9616Test extends CompilerTestContext {
+
+  test(
+    """let 
+      |    date1=Date.Build(2002,1,1),
+      |    date2=Date.Build(2002,2,1),
+      |    date3=Date.Build(2002,1,31)
+      |in 
+      |    {Date.Subtract(date2,date1), Date.Subtract(date3,date1)}""".stripMargin
+  )(it => it should evaluateTo("{Interval.Build(days=30, hours=10, minutes=30), Interval.Build(days=30)}"))
+
+  test(
+    """let
+      |    date1=Date.Build(2002,1,1),
+      |    date2=Date.Build(2002,2,1),
+      |    date3=Date.Build(2002,1,31)
+      |in
+      |    {Interval.ToMillis(Date.Subtract(date2,date1)), Interval.ToMillis(Date.Subtract(date3,date1))}""".stripMargin
+  )(it => it should evaluateTo("{2629800000L, 2592000000L}"))
+
+}

--- a/snapi-client/src/test/scala/raw/compiler/rql2/tests/truffle/regressions/TruffleRegressionTest.scala
+++ b/snapi-client/src/test/scala/raw/compiler/rql2/tests/truffle/regressions/TruffleRegressionTest.scala
@@ -70,6 +70,7 @@ import raw.testing.tags.TruffleTests
 @TruffleTests class RD9409TruffleTest extends TruffleCompilerTestContext with RD9409Test
 @TruffleTests class RD9479TruffleTest extends TruffleCompilerTestContext with RD9479Test
 @TruffleTests class RD9554TruffleTest extends TruffleCompilerTestContext with RD9554Test
+@TruffleTests class RD9616TruffleTest extends TruffleCompilerTestContext with RD9616Test
 @TruffleTests class RD10194TruffleTest extends TruffleCompilerTestContext with RD10194Test
 @TruffleTests class RD10220TruffleTest extends TruffleCompilerTestContext with RD10220Test
 @TruffleTests class RD10723TruffleTest extends TruffleCompilerTestContext with RD10723Test

--- a/snapi-truffle/src/main/java/raw/runtime/truffle/ast/expressions/builtin/temporals/interval_package/IntervalNodes.java
+++ b/snapi-truffle/src/main/java/raw/runtime/truffle/ast/expressions/builtin/temporals/interval_package/IntervalNodes.java
@@ -208,11 +208,12 @@ public class IntervalNodes {
 
       double totalDays = yearsInDays + monthsInDays + 7 * interval.getWeeks() + interval.getDays();
 
-      return 24 * 3600000 * (long) totalDays
-          + 3600000 * (long) interval.getHours()
-          + 60000 * (long) interval.getMinutes()
-          + 1000 * (long) interval.getSeconds()
-          + interval.getMillis();
+      return (long)
+          (24 * 3600000 * totalDays
+              + 3600000 * interval.getHours()
+              + 60000 * interval.getMinutes()
+              + 1000 * interval.getSeconds()
+              + interval.getMillis());
     }
   }
 


### PR DESCRIPTION
Rounding is done last so that we don't round days. It was a mistake. Added a test that would fail without the patch (both computations would mistakenly return 30 days).