### PR TITLE
graal 21 publish and dynver

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -34,22 +34,6 @@ jobs:
       run: |
         deps/kiama/build.sh
         deps/scala-logging/build.sh
-    - if: github.event_name == 'repository_dispatch'
-      name: evaluate produced version
-      shell: bash
-      working-directory: language
-      run: |
-        sbt -Dsbt.log.noformat=true version > version_output.txt 2>&1
-        echo "DYNVER=$(awk {print $2}' version_output.txt | tail -n 1 | awk '{$1=$1;print}')" >> $GITHUB_ENV
-    - if: github.event_name == 'repository_dispatch'
-      uses: peter-evans/create-or-update-comment@v2
-      with:
-        token: ${{ secrets.RAW_CI_PAT }}
-        repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
-        comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
-        body: |
-          > will publish version: ${{ env.DYNVER }}
-        reactions: rocket
     - run: sbt ci-release
       working-directory: language
       env:
@@ -60,6 +44,19 @@ jobs:
         CI_CLEAN: clean
         CI_RELEASE: publishSigned
         CI_SNAPSHOT_RELEASE: publish
+    - name: evaluate produced version
+      shell: bash
+      working-directory: language
+      run: echo "DYNVER=$(cat version)" >> $GITHUB_ENV
+    - if: github.event_name == 'repository_dispatch'
+      uses: peter-evans/create-or-update-comment@v2
+      with:
+        token: ${{ secrets.RAW_CI_PAT }}
+        repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+        comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+        body: |
+          > will publish version: ${{ env.DYNVER }}
+        reactions: rocket
     - if: success() && github.event_name == 'push' && contains(github.ref, 'refs/tags/')
       uses: peter-evans/repository-dispatch@v2
       with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,17 +4,17 @@ on:
     types: [publish]
   workflow_dispatch:
   push:
-    branches:
-      - master
-      - main
-    paths:
-      - raw-*/**
     tags:
       - "v*.*.*"
 jobs:
   build:
-    #(ybo)(todo): migrate to self-hosted
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
+    container:
+      image: ghcr.io/raw-labs/raw-scala-runner:21.0.0-ol9-20230919_scala2.12.18_sbt1.6.2
+      options: --user 1001 --cpus 6 --memory 32g -e HOME=/home/sbtuser
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.READ_PACKAGES }}
     env:
       JAVA_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
       JVM_OPTS:  -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
@@ -30,17 +30,17 @@ jobs:
       with:
         ref: ${{ github.event.client_payload.pull_request.head.sha }}
         fetch-depth: 0
-    - uses: actions/setup-java@v3
-      with:
-        distribution: temurin
-        java-version: 11
-        cache: sbt
+    - name: build deps
+      run: |
+        deps/kiama/build.sh
+        deps/scala-loggings/build.sh
     - if: github.event_name == 'repository_dispatch'
       name: evaluate produced version
       shell: bash
+      working-directory: language
       run: |
         sbt -Dsbt.log.noformat=true version > version_output.txt 2>&1
-        echo "DYNVER=$(awk -F '\t' '/\t[[:digit:]]/ {print $2}' version_output.txt | tail -n 1 | awk '{$1=$1;print}')" >> $GITHUB_ENV
+        echo "DYNVER=$(awk {print $2}' version_output.txt | tail -n 1 | awk '{$1=$1;print}')" >> $GITHUB_ENV
     - if: github.event_name == 'repository_dispatch'
       uses: peter-evans/create-or-update-comment@v2
       with:
@@ -51,6 +51,7 @@ jobs:
           > will publish version: ${{ env.DYNVER }}
         reactions: rocket
     - run: sbt ci-release
+      working-directory: language
       env:
         SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
         SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -33,7 +33,7 @@ jobs:
     - name: build deps
       run: |
         deps/kiama/build.sh
-        deps/scala-loggings/build.sh
+        deps/scala-logging/build.sh
     - if: github.event_name == 'repository_dispatch'
       name: evaluate produced version
       shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ out/
 target/
 /.project
 *.iml
+
+language/version

--- a/extensions/project/Dependencies.scala
+++ b/extensions/project/Dependencies.scala
@@ -5,16 +5,7 @@ import java.util.Properties
 
 object Dependencies {
 
-  val rawLanguageVersion = {
-    val properties = new Properties()
-    val fs = new FileInputStream("../version.properties")
-    try {
-      properties.load(fs)
-      properties.getProperty("language.version")
-    } finally {
-      fs.close()
-    }
-  }
+  val rawLanguageVersion = IO.read(new File("../language/version")).trim
 
   val rawLanguage = "com.raw-labs" %% "raw-language" % rawLanguageVersion
 

--- a/extensions/project/Dependencies.scala
+++ b/extensions/project/Dependencies.scala
@@ -5,7 +5,14 @@ import java.util.Properties
 
 object Dependencies {
 
-  val rawLanguageVersion = IO.read(new File("../language/version")).trim
+  val versionFile = new File("../language/version")
+  
+  val rawLanguageVersion: String = 
+    if (versionFile.exists()) {
+      IO.read(versionFile).trim
+    } else {
+      "0.0.0" // Default version number if the file doesn't exist.
+    }
 
   val rawLanguage = "com.raw-labs" %% "raw-language" % rawLanguageVersion
 

--- a/language/build.sbt
+++ b/language/build.sbt
@@ -30,16 +30,6 @@ licenses/APL.txt."""
 // Read version to use
 import java.util.Properties
 import java.io.FileInputStream
-version := {
-  val properties = new Properties()
-  val fs = new FileInputStream("../version.properties")
-  try {
-    properties.load(fs)
-    properties.getProperty("language.version")
-  } finally {
-    fs.close()
-  }
-}
 
 headerLicense := Some(HeaderLicense.Custom(licenseHeader))
 

--- a/language/build.sbt
+++ b/language/build.sbt
@@ -272,6 +272,9 @@ lazy val outputVersion = taskKey[Unit]("Outputs the version to a file")
 
 outputVersion := {
   val versionFile = baseDirectory.value / "version"
+  if (!versionFile.exists()) {
+    IO.touch(versionFile)
+  }
   IO.write(versionFile, version.value)
 }
 

--- a/language/build.sbt
+++ b/language/build.sbt
@@ -266,3 +266,13 @@ libraryDependencies ++= Seq(
   poiDeps ++
   scalaCompiler ++
   truffleDeps
+
+// auto output version to a file on compile
+lazy val outputVersion = taskKey[Unit]("Outputs the version to a file")
+
+outputVersion := {
+  val versionFile = baseDirectory.value / "version"
+  IO.write(versionFile, version.value)
+}
+
+(compile in Compile) := ((compile in Compile) dependsOn outputVersion).value

--- a/language/build.sh
+++ b/language/build.sh
@@ -3,7 +3,7 @@ SCRIPT_HOME="$(cd "$(dirname "$0")"; pwd)"
 [ "$CI" == "true" ] && { export HOME=/home/sbtuser; }
 . ~/.sdkman/bin/sdkman-init.sh
 
-yes no | sdk install java 21-graalce || true
+yes | sdk install java 21-graalce || true
 sdk use java 21-graalce
 
 cd "$SCRIPT_HOME"


### PR DESCRIPTION
- adds sbt task in order to output the dynver of language in version file
- extension is now reading from version file
- publish worfklow adapted to publish language package

:warning: publish workflow from pr will not work until merge to main branch. publish workflow is triggered from a repository_dispatch event, in github when a workflow is triggered from dispatch_event the workflow file is taken from the default_branch = main in our case