### PR TITLE
compile depends on generateParser + antl4 jar as sbt dep

### DIFF
--- a/snapi-frontend/build.sbt
+++ b/snapi-frontend/build.sbt
@@ -205,3 +205,5 @@ generateParser := {
 }
 
 Compile / packageBin / packageOptions += Package.ManifestAttributes("Automatic-Module-Name" -> "raw.snapi.frontend")
+
+Compile / compile := (Compile / compile).dependsOn(generateParser).value

--- a/snapi-frontend/build.sbt
+++ b/snapi-frontend/build.sbt
@@ -207,3 +207,5 @@ generateParser := {
 Compile / packageBin / packageOptions += Package.ManifestAttributes("Automatic-Module-Name" -> "raw.snapi.frontend")
 
 Compile / compile := (Compile / compile).dependsOn(generateParser).value
+
+publishLocal := (publishLocal dependsOn generateParser).value


### PR DESCRIPTION
- [ ] ref antl4 as lib deps in plugins.sbt + retrieve path of the jar from sbt generateParser