### PR TITLE
Relax memory pressure when allocating inferrers

### DIFF
--- a/snapi-frontend/src/main/scala/raw/compiler/base/TreeWithPositions.scala
+++ b/snapi-frontend/src/main/scala/raw/compiler/base/TreeWithPositions.scala
@@ -53,7 +53,7 @@ abstract class TreeWithPositions[N <: BaseNode: Manifest, P <: N: Manifest, E <:
 
   override protected def isTreeValid: Boolean = {
     val isValid = super.isTreeValid
-    logTree(isValid)
+    if (programContext.settings.onTrainingWheels) logTree(isValid)
     isValid
   }
 

--- a/snapi-frontend/src/main/scala/raw/inferrer/api/DateTimeFormatFinder.scala
+++ b/snapi-frontend/src/main/scala/raw/inferrer/api/DateTimeFormatFinder.scala
@@ -131,31 +131,3 @@ object DateTimeFormatFinder {
   }
 
 }
-
-trait DatetimeFormatFinder {
-
-  def getDate(str: String): Option[(String, LocalDate)] = {
-    DateTimeFormatFinder.getDate(str)
-  }
-
-  def getTimestamp(str: String): Option[(String, LocalDateTime)] = {
-    DateTimeFormatFinder.getTimestamp(str)
-  }
-
-  def getTime(str: String): Option[(String, LocalTime)] = {
-    DateTimeFormatFinder.getTime(str)
-  }
-
-  def tryDateFormat(value: String, format: String): Boolean = {
-    DateTimeFormatFinder.tryDateFormat(value, format)
-  }
-
-  def tryTimeFormat(value: String, format: String): Boolean = {
-    DateTimeFormatFinder.tryTimeFormat(value, format)
-  }
-
-  def tryTimestampFormat(value: String, format: String): Boolean = {
-    DateTimeFormatFinder.tryTimestampFormat(value, format)
-  }
-
-}

--- a/snapi-frontend/src/main/scala/raw/inferrer/api/DateTimeFormatFinder.scala
+++ b/snapi-frontend/src/main/scala/raw/inferrer/api/DateTimeFormatFinder.scala
@@ -15,8 +15,7 @@ package raw.inferrer.api
 import java.time._
 import java.time.format.{DateTimeFormatter, DateTimeParseException}
 
-trait DatetimeFormatFinder {
-
+object DateTimeFormatFinder {
   final private val timeFormats = Seq("H:m", "h:m a", "H:m:s", "h:m:s a", "H:m:s.SSS", "h:m:s.SSS a", "HHmmss")
 
   // TODO:  To be able to year 99 as 1999 use a DateTimeFormatBuilder as shown in:
@@ -129,6 +128,34 @@ trait DatetimeFormatFinder {
       case _: DateTimeParseException =>
     }
     false
+  }
+
+}
+
+trait DatetimeFormatFinder {
+
+  def getDate(str: String): Option[(String, LocalDate)] = {
+    DateTimeFormatFinder.getDate(str)
+  }
+
+  def getTimestamp(str: String): Option[(String, LocalDateTime)] = {
+    DateTimeFormatFinder.getTimestamp(str)
+  }
+
+  def getTime(str: String): Option[(String, LocalTime)] = {
+    DateTimeFormatFinder.getTime(str)
+  }
+
+  def tryDateFormat(value: String, format: String): Boolean = {
+    DateTimeFormatFinder.tryDateFormat(value, format)
+  }
+
+  def tryTimeFormat(value: String, format: String): Boolean = {
+    DateTimeFormatFinder.tryTimeFormat(value, format)
+  }
+
+  def tryTimestampFormat(value: String, format: String): Boolean = {
+    DateTimeFormatFinder.tryTimestampFormat(value, format)
   }
 
 }

--- a/snapi-frontend/src/main/scala/raw/inferrer/local/TextTypeInferrer.scala
+++ b/snapi-frontend/src/main/scala/raw/inferrer/local/TextTypeInferrer.scala
@@ -24,7 +24,9 @@ case class CleanedTemporalFormats(
     timestampFormat: Option[String]
 )
 
-private[inferrer] trait TextTypeInferrer extends DatetimeFormatFinder {
+private[inferrer] trait TextTypeInferrer {
+
+  import DateTimeFormatFinder._
 
   def getType(value: String, currentType: SourceType): SourceType = {
     (currentType: @unchecked) match {


### PR DESCRIPTION
Declared all the formatters in an object. When profiling, those were dominating the memory. That fix permitted to run 78K semantic analysis without hitting OutOfMemory.

This would lead to a leak only if we never free Inferrers. Maybe this is the case?