### PR TITLE
fix(snapi-client)(tests): change expected error message

### DIFF
--- a/snapi-client/src/test/scala/raw/compiler/rql2/tests/builtin/credentials/OraclePackageTest.scala
+++ b/snapi-client/src/test/scala/raw/compiler/rql2/tests/builtin/credentials/OraclePackageTest.scala
@@ -147,7 +147,7 @@ trait OraclePackageTest extends CompilerTestContext with CredentialsTestContext 
       |)""".stripMargin
   ) { it =>
     assume(!compilerService.language.contains("rql2-truffle"))
-    it should runErrorAs("""error connecting to database: example.com""".stripMargin)
+    it should runErrorAs("""connect timed out: example.com""".stripMargin)
   }
 
   // wrong port


### PR DESCRIPTION
I guess at some point `example.com` got sick of people spaming them with some requests and changed their firewall rule.
A quickfix is to adapt the expected error message to what they provide now.
If we really want to still test the fact we get ```error connecting to database: <some_host>.<some_dot_domain>``` we might need to find another external url to spam