### PR TITLE
RD-10206: Setting RDBMS fetch size from config

### DIFF
--- a/snapi-frontend/src/main/java/module-info.java
+++ b/snapi-frontend/src/main/java/module-info.java
@@ -21,6 +21,10 @@ module raw.snapi.frontend {
   requires java.sql;
   requires com.ctc.wstx;
   requires kiama;
+  requires org.postgresql.jdbc;
+  requires mysql.connector.j;
+  requires com.microsoft.sqlserver.jdbc;
+  requires snowflake.jdbc;
   requires org.apache.commons.io;
   requires org.apache.commons.lang3;
   requires org.apache.commons.text;
@@ -111,6 +115,7 @@ module raw.snapi.frontend {
   opens raw.rest.common to
       com.fasterxml.jackson.databind;
 
+  uses org.postgresql.util.PSQLException;
   uses raw.inferrer.api.InferrerServiceBuilder;
 
   provides raw.inferrer.api.InferrerServiceBuilder with

--- a/snapi-frontend/src/test/scala/raw/creds/api/CredentialsTestContext.scala
+++ b/snapi-frontend/src/test/scala/raw/creds/api/CredentialsTestContext.scala
@@ -62,6 +62,12 @@ trait CredentialsTestContext extends BeforeAndAfterAll {
     newHttpCreds.foreach { case (user, (name, cred)) => credentials.registerNewHttpCredential(user, name, cred) }
     dropboxTokens.foreach { case (user, token) => credentials.registerDropboxToken(user, token) }
     secrets.foreach { case (user, secret) => credentials.registerSecret(user, secret) }
+    // Set the system properties for the credentials so that this is overriding what RawLanguage
+    // runs with. This way, the credential server booted by the test framework is used.
+    for (property <- Seq("raw.creds.impl", "raw.creds.client.server-address")) {
+      System.clearProperty(property)
+      settings.getStringOpt(property).foreach(v => System.setProperty(property, v))
+    }
   }
 
   override def afterAll(): Unit = {

--- a/snapi-truffle/src/main/java/raw/runtime/truffle/ast/io/jdbc/JdbcQuery.java
+++ b/snapi-truffle/src/main/java/raw/runtime/truffle/ast/io/jdbc/JdbcQuery.java
@@ -47,8 +47,10 @@ public class JdbcQuery {
     try {
       connection = JdbcLocationProvider.build(locationDescription, context).getJdbcConnection();
       PreparedStatement stmt;
+      int fetchSize = context.settings().getInt("raw.runtime.rdbms.fetch-size");
       try {
         stmt = connection.prepareStatement(query);
+        stmt.setFetchSize(fetchSize);
         rs = stmt.executeQuery();
       } catch (SQLException e) {
         throw exceptionHandler.rewrite(e, this);

--- a/snapi-truffle/src/main/resources/reference.conf
+++ b/snapi-truffle/src/main/resources/reference.conf
@@ -11,4 +11,9 @@ raw.runtime {
     input-buffer-size = 16M
   }
 
+  rdbms {
+    fetch-size = 100000
+    log-after-rows = 100000
+  }
+
 }


### PR DESCRIPTION
When running `PostgreSQLPackageTruffleTest`, that line appears in the logs when using a `PostgreSQL` database. Same with other backends.
```
Using raw.runtime.rdbms.fetch-size: 100000 (int)
```

Some tests processing errors using the `Exception` out of the JDBC call, failed because of missing module declarations.
```
Actual: java.lang.IllegalAccessError: class raw.sources.jdbc.pgsql.PostgresqlClient (in module raw.snapi.frontend) cannot access class org.postgresql.util.PSQLException (in unnamed module @0x479d31f3) because module raw.snapi.frontend does not read unnamed module @0x479d31f3
```