### PR TITLE
RD-10218: Don't report internal errors (exceptions due to internal errors) as a user-visible error

### DIFF
--- a/snapi-client/src/main/scala/raw/client/rql2/truffle/Rql2TruffleCompilerService.scala
+++ b/snapi-client/src/main/scala/raw/client/rql2/truffle/Rql2TruffleCompilerService.scala
@@ -404,11 +404,8 @@ class Rql2TruffleCompilerService(maybeClassLoader: Option[ClassLoader] = None)(
             }
             ExecutionValidationFailure(errors.to)
           } else {
-            if (ex.isInternalError) {
-              val programContext = getProgramContext(environment.user, environment)
-              throw new CompilerServiceException(ex, programContext.dumpDebugInfo)
-            }
-            ExecutionRuntimeFailure(ex.getMessage)
+            val programContext = getProgramContext(environment.user, environment)
+            throw new CompilerServiceException(ex, programContext.dumpDebugInfo)
           }
         } else {
           // Unexpected error. For now we throw the PolyglotException.

--- a/snapi-client/src/main/scala/raw/client/rql2/truffle/Rql2TruffleCompilerService.scala
+++ b/snapi-client/src/main/scala/raw/client/rql2/truffle/Rql2TruffleCompilerService.scala
@@ -404,6 +404,10 @@ class Rql2TruffleCompilerService(maybeClassLoader: Option[ClassLoader] = None)(
             }
             ExecutionValidationFailure(errors.to)
           } else {
+            if (ex.isInternalError) {
+              val programContext = getProgramContext(environment.user, environment)
+              throw new CompilerServiceException(ex, programContext.dumpDebugInfo)
+            }
             ExecutionRuntimeFailure(ex.getMessage)
           }
         } else {

--- a/snapi-client/src/main/scala/raw/client/rql2/truffle/Rql2TruffleCompilerService.scala
+++ b/snapi-client/src/main/scala/raw/client/rql2/truffle/Rql2TruffleCompilerService.scala
@@ -412,7 +412,9 @@ class Rql2TruffleCompilerService(maybeClassLoader: Option[ClassLoader] = None)(
               }
               ExecutionValidationFailure(errors.to)
             } else {
-              // A runtime failure during execution. The query is a failed tryable.
+              // A runtime failure during execution. The query could be a failed tryable, or a runtime error (e.g. a
+              // file not found) hit when processing a reader that evaluates as a _collection_ (processed outside the
+              // evaluation of the query).
               ExecutionRuntimeFailure(ex.getMessage)
             }
           }

--- a/snapi-client/src/main/scala/raw/client/rql2/truffle/Rql2TruffleCompilerService.scala
+++ b/snapi-client/src/main/scala/raw/client/rql2/truffle/Rql2TruffleCompilerService.scala
@@ -404,8 +404,12 @@ class Rql2TruffleCompilerService(maybeClassLoader: Option[ClassLoader] = None)(
             }
             ExecutionValidationFailure(errors.to)
           } else {
-            val programContext = getProgramContext(environment.user, environment)
-            throw new CompilerServiceException(ex, programContext.dumpDebugInfo)
+            if (ex.isInternalError) {
+              val programContext = getProgramContext(environment.user, environment)
+              throw new CompilerServiceException(ex, programContext.dumpDebugInfo)
+            } else {
+              ExecutionRuntimeFailure(ex.getMessage)
+            }
           }
         } else {
           // Unexpected error. For now we throw the PolyglotException.

--- a/snapi-client/src/main/scala/raw/client/rql2/truffle/Rql2TruffleCompilerService.scala
+++ b/snapi-client/src/main/scala/raw/client/rql2/truffle/Rql2TruffleCompilerService.scala
@@ -386,28 +386,33 @@ class Rql2TruffleCompilerService(maybeClassLoader: Option[ClassLoader] = None)(
         } else if (ex.getMessage.startsWith("java.lang.InterruptedException")) {
           throw new InterruptedException()
         } else if (ex.isGuestException) {
-          val err = ex.getGuestObject
-          if (err != null && err.hasMembers && err.hasMember("errors")) {
-            val errorsValue = err.getMember("errors")
-            val errors = (0L until errorsValue.getArraySize).map { i =>
-              val errorValue = errorsValue.getArrayElement(i)
-              val message = errorValue.asString
-              val positions = (0L until errorValue.getArraySize).map { j =>
-                val posValue = errorValue.getArrayElement(j)
-                val beginValue = posValue.getMember("begin")
-                val endValue = posValue.getMember("end")
-                val begin = ErrorPosition(beginValue.getMember("line").asInt, beginValue.getMember("column").asInt)
-                val end = ErrorPosition(endValue.getMember("line").asInt, endValue.getMember("column").asInt)
-                ErrorRange(begin, end)
-              }
-              ErrorMessage(message, positions.to)
-            }
-            ExecutionValidationFailure(errors.to)
+          if (ex.isInternalError) {
+            // An internal error. It means a regular Exception thrown from the language (e.g. a Java Exception,
+            // or a RawTruffleInternalErrorException, which isn't an AbstractTruffleException)
+            val programContext = getProgramContext(environment.user, environment)
+            throw new CompilerServiceException(ex, programContext.dumpDebugInfo)
           } else {
-            if (ex.isInternalError) {
-              val programContext = getProgramContext(environment.user, environment)
-              throw new CompilerServiceException(ex, programContext.dumpDebugInfo)
+            val err = ex.getGuestObject
+            if (err != null && err.hasMembers && err.hasMember("errors")) {
+              // A validation exception, semantic or syntax error (both come as the same kind of error)
+              // that has a list of errors and their positions.
+              val errorsValue = err.getMember("errors")
+              val errors = (0L until errorsValue.getArraySize).map { i =>
+                val errorValue = errorsValue.getArrayElement(i)
+                val message = errorValue.asString
+                val positions = (0L until errorValue.getArraySize).map { j =>
+                  val posValue = errorValue.getArrayElement(j)
+                  val beginValue = posValue.getMember("begin")
+                  val endValue = posValue.getMember("end")
+                  val begin = ErrorPosition(beginValue.getMember("line").asInt, beginValue.getMember("column").asInt)
+                  val end = ErrorPosition(endValue.getMember("line").asInt, endValue.getMember("column").asInt)
+                  ErrorRange(begin, end)
+                }
+                ErrorMessage(message, positions.to)
+              }
+              ExecutionValidationFailure(errors.to)
             } else {
+              // A runtime failure during execution. The query is a failed tryable.
               ExecutionRuntimeFailure(ex.getMessage)
             }
           }

--- a/snapi-client/src/test/scala/raw/compiler/rql2/tests/builtin/IntPackageTest.scala
+++ b/snapi-client/src/test/scala/raw/compiler/rql2/tests/builtin/IntPackageTest.scala
@@ -16,6 +16,27 @@ import raw.compiler.rql2.tests.CompilerTestContext
 
 trait IntPackageTest extends CompilerTestContext {
 
-  test("""let x = [List.Transform, null]
-    |in List.Count(x)""".stripMargin)(t => executeQuery(t.q))
+  test(""" Int.From(1)""")(it => it should evaluateTo("1"))
+
+  test(""" Int.From("1")""")(it => it should evaluateTo("1"))
+
+  test(""" Int.From(1.5)""")(it => it should evaluateTo("1"))
+
+  test(""" Int.From(1.5f)""")(it => it should evaluateTo("1"))
+
+  test(""" Int.From(List.Build(1, 2, 3))""")(it =>
+    it should typeErrorAs("expected either number or string but got list(int)")
+  )
+
+  test(""" Int.From("abc")""")(it => it should runErrorAs("cannot cast 'abc' to int"))
+
+  // Errors don't propagate through
+  test(""" [Int.From("abc") + 12]""")(it => it should evaluateTo("""[Error.Build("cannot cast 'abc' to int")]"""))
+
+  // Nullability is handled
+  test(""" [Int.From("abc" + null) + 12]""")(it => it should evaluateTo("""[null]"""))
+  test(""" [Int.From(1b + null) + 12b]""")(it => it should evaluateTo("""[null]"""))
+
+  // Range tests
+  test("""Long.Range(0,2,step=1)""")(it => it should evaluateTo("""Collection.Build(0L,1L)"""))
 }

--- a/snapi-client/src/test/scala/raw/compiler/rql2/tests/builtin/IntPackageTest.scala
+++ b/snapi-client/src/test/scala/raw/compiler/rql2/tests/builtin/IntPackageTest.scala
@@ -16,27 +16,7 @@ import raw.compiler.rql2.tests.CompilerTestContext
 
 trait IntPackageTest extends CompilerTestContext {
 
-  test(""" Int.From(1)""")(it => it should evaluateTo("1"))
-
-  test(""" Int.From("1")""")(it => it should evaluateTo("1"))
-
-  test(""" Int.From(1.5)""")(it => it should evaluateTo("1"))
-
-  test(""" Int.From(1.5f)""")(it => it should evaluateTo("1"))
-
-  test(""" Int.From(List.Build(1, 2, 3))""")(it =>
-    it should typeErrorAs("expected either number or string but got list(int)")
-  )
-
-  test(""" Int.From("abc")""")(it => it should runErrorAs("cannot cast 'abc' to int"))
-
-  // Errors don't propagate through
-  test(""" [Int.From("abc") + 12]""")(it => it should evaluateTo("""[Error.Build("cannot cast 'abc' to int")]"""))
-
-  // Nullability is handled
-  test(""" [Int.From("abc" + null) + 12]""")(it => it should evaluateTo("""[null]"""))
-  test(""" [Int.From(1b + null) + 12b]""")(it => it should evaluateTo("""[null]"""))
-
-  // Range tests
-  test("""Long.Range(0,2,step=1)""")(it => it should evaluateTo("""Collection.Build(0L,1L)"""))
+  test(
+    """let x = [List.Transform, null]
+      |in List.Count(x)""".stripMargin)(t => executeQuery(t.q))
 }

--- a/snapi-client/src/test/scala/raw/compiler/rql2/tests/builtin/IntPackageTest.scala
+++ b/snapi-client/src/test/scala/raw/compiler/rql2/tests/builtin/IntPackageTest.scala
@@ -16,7 +16,6 @@ import raw.compiler.rql2.tests.CompilerTestContext
 
 trait IntPackageTest extends CompilerTestContext {
 
-  test(
-    """let x = [List.Transform, null]
-      |in List.Count(x)""".stripMargin)(t => executeQuery(t.q))
+  test("""let x = [List.Transform, null]
+    |in List.Count(x)""".stripMargin)(t => executeQuery(t.q))
 }

--- a/snapi-truffle/src/main/java/raw/runtime/truffle/RawLanguage.java
+++ b/snapi-truffle/src/main/java/raw/runtime/truffle/RawLanguage.java
@@ -154,21 +154,16 @@ public final class RawLanguage extends TruffleLanguage<RawContext> {
       } else {
         throw new RawTruffleValidationException(JavaConverters.seqAsJavaList(tree.errors()));
       }
-    } catch (RuntimeException e) {
-      if (e.getCause() instanceof CompilerParserException) {
-        CompilerParserException ex = (CompilerParserException) e.getCause();
-        throw new RawTruffleValidationException(
-            java.util.Collections.singletonList(
-                new ErrorMessage(
-                    ex.getMessage(),
-                    JavaConverters.asScalaBufferConverter(
-                            java.util.Collections.singletonList(
-                                new ErrorRange(ex.position(), ex.position())))
-                        .asScala()
-                        .toList())));
-      } else {
-        throw e;
-      }
+    } catch (CompilerParserException ex) {
+      throw new RawTruffleValidationException(
+          java.util.Collections.singletonList(
+              new ErrorMessage(
+                  ex.getMessage(),
+                  JavaConverters.asScalaBufferConverter(
+                          java.util.Collections.singletonList(
+                              new ErrorRange(ex.position(), ex.position())))
+                      .asScala()
+                      .toList())));
     }
   }
 

--- a/snapi-truffle/src/main/java/raw/runtime/truffle/runtime/exceptions/RawTruffleInternalErrorException.java
+++ b/snapi-truffle/src/main/java/raw/runtime/truffle/runtime/exceptions/RawTruffleInternalErrorException.java
@@ -12,27 +12,24 @@
 
 package raw.runtime.truffle.runtime.exceptions;
 
-import com.oracle.truffle.api.exception.AbstractTruffleException;
 import com.oracle.truffle.api.nodes.Node;
 
 // This exception is thrown when an internal error occurs in the Raw Truffle runtime.
-public class RawTruffleInternalErrorException extends AbstractTruffleException {
-
-  private static final String message = "Internal error";
+public class RawTruffleInternalErrorException extends RuntimeException {
 
   public RawTruffleInternalErrorException() {
-    super(message);
+    super("internal error");
   }
 
   public RawTruffleInternalErrorException(String message) {
     super(message);
   }
 
-  public RawTruffleInternalErrorException(Throwable cause) {
-    super(message, cause, UNLIMITED_STACK_TRACE, null);
+  public RawTruffleInternalErrorException(Throwable cause, Node location) {
+    super(location.getDescription(), cause);
   }
 
-  public RawTruffleInternalErrorException(Throwable cause, Node location) {
-    super(message, cause, UNLIMITED_STACK_TRACE, location);
+  public RawTruffleInternalErrorException(Throwable cause) {
+    super(cause);
   }
 }

--- a/snapi-truffle/src/main/java/raw/runtime/truffle/runtime/exceptions/RawTruffleRuntimeException.java
+++ b/snapi-truffle/src/main/java/raw/runtime/truffle/runtime/exceptions/RawTruffleRuntimeException.java
@@ -14,8 +14,13 @@ package raw.runtime.truffle.runtime.exceptions;
 
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.exception.AbstractTruffleException;
+import com.oracle.truffle.api.interop.ExceptionType;
+import com.oracle.truffle.api.interop.InteropLibrary;
+import com.oracle.truffle.api.library.ExportLibrary;
+import com.oracle.truffle.api.library.ExportMessage;
 import com.oracle.truffle.api.nodes.Node;
 
+@ExportLibrary(InteropLibrary.class)
 public class RawTruffleRuntimeException extends AbstractTruffleException {
 
   //    private static final TruffleLogger LOG = TruffleLogger.getLogger(RawLanguage.ID,
@@ -45,5 +50,10 @@ public class RawTruffleRuntimeException extends AbstractTruffleException {
 
     super(ex.toString(), location);
     //        this.location = location;
+  }
+
+  @ExportMessage
+  public ExceptionType getExceptionType() {
+    return ExceptionType.EXIT;
   }
 }

--- a/snapi-truffle/src/main/java/raw/runtime/truffle/runtime/exceptions/RawTruffleRuntimeException.java
+++ b/snapi-truffle/src/main/java/raw/runtime/truffle/runtime/exceptions/RawTruffleRuntimeException.java
@@ -54,6 +54,6 @@ public class RawTruffleRuntimeException extends AbstractTruffleException {
 
   @ExportMessage
   public ExceptionType getExceptionType() {
-    return ExceptionType.RUNTIME;
+    return ExceptionType.RUNTIME_ERROR;
   }
 }

--- a/snapi-truffle/src/main/java/raw/runtime/truffle/runtime/exceptions/RawTruffleRuntimeException.java
+++ b/snapi-truffle/src/main/java/raw/runtime/truffle/runtime/exceptions/RawTruffleRuntimeException.java
@@ -54,6 +54,6 @@ public class RawTruffleRuntimeException extends AbstractTruffleException {
 
   @ExportMessage
   public ExceptionType getExceptionType() {
-    return ExceptionType.EXIT;
+    return ExceptionType.RUNTIME;
   }
 }

--- a/snapi-truffle/src/main/java/raw/runtime/truffle/tryable_nullable/Tryable.java
+++ b/snapi-truffle/src/main/java/raw/runtime/truffle/tryable_nullable/Tryable.java
@@ -12,6 +12,7 @@
 
 package raw.runtime.truffle.tryable_nullable;
 
+import raw.runtime.truffle.runtime.exceptions.RawTruffleRuntimeException;
 import raw.runtime.truffle.runtime.primitives.ErrorObject;
 
 public class Tryable {
@@ -24,7 +25,7 @@ public class Tryable {
   }
 
   public static String getFailure(Object value) {
-    if (!isFailure(value)) throw new RuntimeException("not a failure");
+    if (!isFailure(value)) throw new RawTruffleRuntimeException("not a failure");
     return ((ErrorObject) value).getMessage();
   }
 }


### PR DESCRIPTION
If hitting an internal error, the exception is caught and mistaken for a user-level one. The discrimination on `.isGuestException` isn't enough.

Our language can throw:
* `RawTruffleRuntimeException` and `RawTruffleValidationException` that have a user-visible message and can be reported as an execution or validation error to the user,
* `RawTruffleInternalErrorException` which is showing an internal error,
* any other regular exception that it triggers by calling libraries: `NoSuchElementException`, `NullPointerException`, etc.

All these exceptions end up wrapped as `PolyglotException`. I noticed method `.isInternalError` returns `true` for regular Java exceptions and `false` for `RawTruffleRuntimeException` and `RawTruffleValidationException`. By checking `.isInternalError`, we get the intended behavior: `RawTruffleRuntimeException` is caught and returned as `ExecutionRuntimeFailure`, and regular unexpected ones are propagated as a `CompilerServiceException`

I believe our `RawTruffleInternalErrorException` should be recognized as internal. Because it inherits `AbstractTruffleException`, it's seen as non-internal and is confused with a `RawTruffleRuntimeException`. So far the only way I was able to distinguish it, was to drop the inheritance with `AbstractTruffleException`.