### PR TITLE
RD-10256: Add the MySQL JDBC module to snapi-frontend

### DIFF
--- a/deps/others/build.sbt
+++ b/deps/others/build.sbt
@@ -11,10 +11,13 @@ val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5"
 
 val jacksonModuleScala = "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.15.2"
 
+val mysqlModule = "com.mysql" % "mysql-connector-j" % "8.1.0"
+
 libraryDependencies ++= Seq(
   jwtCore,
   scalaLogging,
-  jacksonModuleScala
+  jacksonModuleScala,
+  mysqlModule
 )
 
 // Map of artifact ID to module name
@@ -22,6 +25,7 @@ val moduleNames = Map(
   "jwt-core" -> "jwt.core",
   "scala-logging" -> "typesafe.scalalogging",
   "jackson-module-scala" -> "com.fasterxml.jackson.scala",
+  "mysql-connector-j" -> "mysql.connector.j",
 )
 
 def getCoursierCachePath: String = {

--- a/snapi-frontend/project/Dependencies.scala
+++ b/snapi-frontend/project/Dependencies.scala
@@ -31,7 +31,7 @@ object Dependencies {
 
   val postgresqlDeps = "org.postgresql" % "postgresql" % "42.5.4"
 
-  val mysqlDeps = "com.mysql" % "mysql-connector-j" % "8.1.0"
+  val mysqlDeps = "com.mysql" % "mysql-connector-j" % "8.1.0-rawlabs"
 
   val mssqlDeps = "com.microsoft.sqlserver" % "mssql-jdbc" % "7.0.0.jre10"
 

--- a/snapi-frontend/src/main/java/module-info.java
+++ b/snapi-frontend/src/main/java/module-info.java
@@ -62,6 +62,7 @@ module raw.snapi.frontend {
   requires software.amazon.awssdk.utils;
   requires org.postgresql.jdbc;
   requires com.microsoft.sqlserver.jdbc;
+  requires mysql.connector.j;
   requires raw.utils;
   requires raw.client;
 

--- a/snapi-frontend/src/main/scala/raw/sources/jdbc/mysql/MySqlClient.scala
+++ b/snapi-frontend/src/main/scala/raw/sources/jdbc/mysql/MySqlClient.scala
@@ -35,7 +35,7 @@ class MySqlClient(db: MySqlCredential)(implicit settings: RawSettings) extends J
   }
   override val username: Option[String] = db.username
   override val password: Option[String] = db.password
-
+  final private val sillytricktousethemysqlpackage = new CJCommunicationsException("sillytricktousethemysqlpackage")
   override val hostname: String = db.host
 
   override def wrapSQLException[T](f: => T): T = {

--- a/snapi-frontend/src/main/scala/raw/sources/jdbc/mysql/MySqlClient.scala
+++ b/snapi-frontend/src/main/scala/raw/sources/jdbc/mysql/MySqlClient.scala
@@ -35,7 +35,7 @@ class MySqlClient(db: MySqlCredential)(implicit settings: RawSettings) extends J
   }
   override val username: Option[String] = db.username
   override val password: Option[String] = db.password
-  final private val sillytricktousethemysqlpackage = new CJCommunicationsException("sillytricktousethemysqlpackage")
+
   override val hostname: String = db.host
 
   override def wrapSQLException[T](f: => T): T = {


### PR DESCRIPTION
This version requires the patch that renames modules. Without explicitly naming the module, I couldn't get it found at startup.

Without adding the module dependency, running a query leads to:
```
java.lang.IllegalAccessError: class raw.sources.jdbc.mysql.MySqlClient (in module raw.snapi.frontend)
cannot access class com.mysql.cj.exceptions.CJCommunicationsException (in unnamed module @0xb4a355b)
because module raw.snapi.frontend does not read unnamed module @0xb4a355b
```

With the patch, the query returns the expected results.