### PR TITLE
ci: build once, check and test in parallel

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,8 +63,6 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: versions
-      - run: ls -al -R .
-      - run: ls -al -R ./**/version
       - name: headers
         run: sbt headerCheckAll
         working-directory: ${{ matrix.component }}
@@ -104,7 +102,6 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: versions
-          path: ./versions
       - run: sbt test
         working-directory: ${{ matrix.component }}
       - uses: mikepenz/action-junit-report@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,7 +77,7 @@ jobs:
         run: sbt javafmtCheckAll
         working-directory: ${{ matrix.component }}
   tests:
-    needs: code-checks
+    needs: build
     strategy:
       fail-fast: false
       matrix:
@@ -109,7 +109,7 @@ jobs:
         with:
           name: versions
       - run: |
-          test_version=$(cat ${{ matrix.component }}/version)
+          test_version=$(cat ./version)
           echo "Testing ${{ matrix.component }} version: $test_version"
           sbt test
         working-directory: ${{ matrix.component }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,8 @@ jobs:
         password: ${{ secrets.READ_PACKAGES }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - run: ./rebuild.sh
       - name: upload build artifacts
         uses: actions/upload-artifact@v4
@@ -108,10 +110,11 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: versions
-      - run: |
+      - name: test
+        run: |
           test_version=$(cat ./version)
           echo "Testing ${{ matrix.component }} version: $test_version"
-          sbt test
+          ./test.sh
         working-directory: ${{ matrix.component }}
       - uses: mikepenz/action-junit-report@v3
         if: success() || failure()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,7 +63,8 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: versions
-          path: ./**/version
+      - run: ls -al -R .
+      - run: ls -al -R ./**/version
       - name: headers
         run: sbt headerCheckAll
         working-directory: ${{ matrix.component }}
@@ -103,7 +104,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: versions
-          path: ./**/version
+          path: ./versions
       - run: sbt test
         working-directory: ${{ matrix.component }}
       - uses: mikepenz/action-junit-report@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,11 +27,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: ./rebuild.sh
-      - uses: actions/upload-artifact@v4
+      - name: upload build artifacts
+        uses: actions/upload-artifact@v4
         with:
           name: build
           path: /home/sbtuser/.ivy2/local
-      - uses: actions/upload-artifact@v4
+      - name: upload versions
+        uses: actions/upload-artifact@v4
         with:
           name: versions
           path: ./**/version
@@ -56,11 +58,13 @@ jobs:
         password: ${{ secrets.READ_PACKAGES }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - name: download build artifacts
+        uses: actions/download-artifact@v4
         with:
           name: build
           path: /home/sbtuser/.ivy2/local
-      - uses: actions/download-artifact@v4
+      - name: download versions
+        uses: actions/download-artifact@v4
         with:
           name: versions
       - name: headers
@@ -95,14 +99,19 @@ jobs:
       - uses: oNaiPs/secrets-to-env-action@v1
         with:
           secrets: ${{ toJSON(secrets) }}
-      - uses: actions/download-artifact@v4
+      - name: download build artifacts
+        uses: actions/download-artifact@v4
         with:
           name: build
           path: /home/sbtuser/.ivy2/local
-      - uses: actions/download-artifact@v4
+      - name: download versions
+        uses: actions/download-artifact@v4
         with:
           name: versions
-      - run: sbt test
+      - run: |
+          test_version=$(cat ${{ matrix.component }}/version)
+          echo "Testing ${{ matrix.component }} version: $test_version"
+          sbt test
         working-directory: ${{ matrix.component }}
       - uses: mikepenz/action-junit-report@v3
         if: success() || failure()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,16 @@ env:
 
 jobs:
   code-checks:
+    strategy:
+      fail-fast: false
+      matrix:
+        component:
+          - utils
+          - client
+          - snapi-frontend
+          - snapi-truffle
+          - snapi-client
+          - python-client
     runs-on: self-hosted
     container:
       image: ghcr.io/raw-labs/raw-scala-runner:21.0.0-ol9-20230919_scala2.12.18_sbt1.9.6
@@ -25,8 +35,22 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.READ_PACKAGES }}
     steps:
-      - uses: actions/checkout@v3
-
+      - uses: actions/checkout@v4
+      - uses: s4u/setup-maven-action@v1.11.0
+      - name: build deps
+        run: |
+          deps/kiama/build.sh
+          deps/scala-logging/build.sh
+          deps/jackson-module-scala/build.sh
+      - name: headers
+        run: sbt headerCheckAll
+        working-directory: ${{ matrix.component }}
+      - name: scala fmt
+        run: sbt scalafmtCheckAll
+        working-directory: ${{ matrix.component }}
+      - name: java fmt
+        run: sbt javafmtCheckAll
+        working-directory: ${{ matrix.component }}
   tests:
     needs: code-checks
     runs-on: self-hosted
@@ -40,84 +64,31 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.READ_PACKAGES }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: oNaiPs/secrets-to-env-action@v1
         with:
           secrets: ${{ toJSON(secrets) }}
+      - uses: s4u/setup-maven-action@v1.11.0
       - name: build deps
         run: |
           deps/kiama/build.sh
           deps/scala-logging/build.sh
           deps/jackson-module-scala/build.sh
-      - name: utils headers
-        run: sbt headerCheckAll
-        working-directory: utils
-      - name: utils scala fmt
-        run: sbt scalafmtCheckAll
-        working-directory: utils
-      - name: utils java fmt
-        run: sbt javafmtCheckAll
-        working-directory: utils
       - name: build utils
         working-directory: utils
         run: ./build.sh
-      - name: client headers
-        run: sbt headerCheckAll
-        working-directory: client
-      - name: client scala fmt
-        run: sbt scalafmtCheckAll
-        working-directory: client
-      - name: client java fmt
-        run: sbt javafmtCheckAll
-        working-directory: client
       - name: build client
         working-directory: client
         run: ./build.sh
-      - name: snapi-frontend headers
-        run: sbt headerCheckAll
-        working-directory: snapi-frontend
-      - name: snapi-frontend scala fmt
-        run: sbt scalafmtCheckAll
-        working-directory: snapi-frontend
-      - name: snapi-frontend java fmt
-        run: sbt javafmtCheckAll
-        working-directory: snapi-frontend
       - name: build snapi-frontend
         working-directory: snapi-frontend
         run: ./build.sh
-      - name: snapi-truffle headers
-        run: sbt headerCheckAll
-        working-directory: snapi-truffle
-      - name: snapi-truffle scala fmt
-        run: sbt scalafmtCheckAll
-        working-directory: snapi-truffle
-      - name: snapi-truffle java fmt
-        run: sbt javafmtCheckAll
-        working-directory: snapi-truffle
       - name: build snapi-truffle
         working-directory: snapi-truffle
         run: ./build.sh
-      - name: snapi-client headers
-        run: sbt headerCheckAll
-        working-directory: snapi-client
-      - name: snapi-client scala fmt
-        run: sbt scalafmtCheckAll
-        working-directory: snapi-client
-      - name: snapi-client java fmt
-        run: sbt javafmtCheckAll
-        working-directory: snapi-client
       - name: build snapi-client
         working-directory: snapi-client
         run: ./build.sh
-      - name: python-client headers
-        run: sbt headerCheckAll
-        working-directory: python-client
-      - name: python-client scala fmt
-        run: sbt scalafmtCheckAll
-        working-directory: python-client
-      - name: python-client java fmt
-        run: sbt javafmtCheckAll
-        working-directory: python-client
       - name: build python-client
         working-directory: python-client
         run: ./build.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,6 +80,9 @@ jobs:
       - name: java fmt
         run: sbt javafmtCheckAll
         working-directory: ${{ matrix.component }}
+      - name: doc
+        run: sbt doc
+        working-directory: ${{ matrix.component }}
   tests:
     needs: build
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,31 @@ env:
   SBT_OPTS : -Dsbt.log.noformat=true -Xss2m -Xms1g
 
 jobs:
-  code-checks:
+  build-deps:
+    strategy:
+      fail-fast: false
+      matrix:
+        component:
+          - kiama
+          - scala-logging
+          - jackson-module-scala
+    runs-on: self-hosted
+    container:
+      image: ghcr.io/raw-labs/raw-scala-runner:buster_21.0.1.12-1_python3.7_scala2.12.18_sbt1.9.6
+      options: --user 1001
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.READ_PACKAGES }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: s4u/setup-maven-action@v1.11.0
+      - uses: coursier/cache-action@v6
+        with:
+          root: deps/${{ matrix.component }}
+      - run: ./build.sh
+        working-directory: deps/${{ matrix.component }}
+  build:
+    needs: build-deps
     strategy:
       fail-fast: false
       matrix:
@@ -37,11 +61,35 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: s4u/setup-maven-action@v1.11.0
-      - name: build deps
-        run: |
-          deps/kiama/build.sh
-          deps/scala-logging/build.sh
-          deps/jackson-module-scala/build.sh
+      - uses: coursier/cache-action@v6
+        with:
+          root: ${{ matrix.component }}
+      - run: ./build.sh
+        working-directory: ${{ matrix.component }}
+  code-checks:
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        component:
+          - utils
+          - client
+          - snapi-frontend
+          - snapi-truffle
+          - snapi-client
+          - python-client
+    runs-on: self-hosted
+    container:
+      image: ghcr.io/raw-labs/raw-scala-runner:buster_21.0.1.12-1_python3.7_scala2.12.18_sbt1.9.6
+      options: --user 1001
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.READ_PACKAGES }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: coursier/cache-action@v6
+        with:
+          root: ${{ matrix.component }}
       - name: headers
         run: sbt headerCheckAll
         working-directory: ${{ matrix.component }}
@@ -53,6 +101,12 @@ jobs:
         working-directory: ${{ matrix.component }}
   tests:
     needs: code-checks
+    strategy:
+      fail-fast: false
+      matrix:
+        component:
+          - snapi-frontend
+          - snapi-client
     runs-on: self-hosted
     env:
       SBT_FORK_OUTPUT_DIR : test-results
@@ -68,49 +122,11 @@ jobs:
       - uses: oNaiPs/secrets-to-env-action@v1
         with:
           secrets: ${{ toJSON(secrets) }}
-      - uses: s4u/setup-maven-action@v1.11.0
-      - name: build deps
-        run: |
-          deps/kiama/build.sh
-          deps/scala-logging/build.sh
-          deps/jackson-module-scala/build.sh
-      - name: build utils
-        working-directory: utils
-        run: ./build.sh
-      - name: build client
-        working-directory: client
-        run: ./build.sh
-      - name: build snapi-frontend
-        working-directory: snapi-frontend
-        run: ./build.sh
-      - name: build snapi-truffle
-        working-directory: snapi-truffle
-        run: ./build.sh
-      - name: build snapi-client
-        working-directory: snapi-client
-        run: ./build.sh
-      - name: build python-client
-        working-directory: python-client
-        run: ./build.sh
-      - name: utils doc
-        working-directory: utils
-        run: sbt doc
-      - name: client doc
-        working-directory: client
-        run: sbt doc
-      - name: snapi-frontend doc
-        working-directory: snapi-frontend
-        run: sbt doc
-      - name: snapi-truffle doc
-        working-directory: snapi-truffle
-        run: sbt doc
-      - name: snapi-client doc
-        working-directory: snapi-client
-        run: sbt doc
-      - name: python-client doc
-        working-directory: python-client
-        run: sbt doc
-      - run: ./tests.sh
+      - uses: coursier/cache-action@v6
+        with:
+          root: ${{ matrix.component }}
+      - run: sbt test
+        working-directory: ${{ matrix.component }}
       - uses: mikepenz/action-junit-report@v3
         if: success() || failure()
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,11 +34,13 @@ jobs:
         with:
           name: build
           path: /home/sbtuser/.ivy2/local
+          retention-days: 1
       - name: upload versions
         uses: actions/upload-artifact@v4
         with:
           name: versions
           path: ./**/version
+          retention-days: 1
   code-checks:
     needs: build
     strategy:
@@ -125,11 +127,11 @@ jobs:
         with:
           name: executor-logs
           path: test-results/executor-logs
-          retention-days: 7
+          retention-days: 4
           if-no-files-found: ignore
       - uses: actions/upload-artifact@v3
         with:
           name: heap-dumps
           path: test-results/heap-dumps
-          retention-days: 7
+          retention-days: 4
           if-no-files-found: ignore

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,31 +16,27 @@ env:
   SBT_OPTS : -Dsbt.log.noformat=true -Xss2m -Xms1g
 
 jobs:
-  build-deps:
-    strategy:
-      fail-fast: false
-      matrix:
-        component:
-          - kiama
-          - scala-logging
-          - jackson-module-scala
+  build:
     runs-on: self-hosted
     container:
-      image: ghcr.io/raw-labs/raw-scala-runner:buster_21.0.1.12-1_python3.7_scala2.12.18_sbt1.9.6
+      image: ghcr.io/raw-labs/raw-scala-runner:21.0.0-ol9-20230919_scala2.12.18_sbt1.9.6
       options: --user 1001
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.READ_PACKAGES }}
     steps:
       - uses: actions/checkout@v4
-      - uses: s4u/setup-maven-action@v1.11.0
-      - uses: coursier/cache-action@v6
+      - run: ./rebuild.sh
+      - uses: actions/upload-artifact@v4
         with:
-          root: deps/${{ matrix.component }}
-      - run: ./build.sh
-        working-directory: deps/${{ matrix.component }}
-  build:
-    needs: build-deps
+          name: build
+          path: /home/sbtuser/.ivy2/local
+      - uses: actions/upload-artifact@v4
+        with:
+          name: versions
+          path: ./**/version
+  code-checks:
+    needs: build
     strategy:
       fail-fast: false
       matrix:
@@ -60,36 +56,14 @@ jobs:
         password: ${{ secrets.READ_PACKAGES }}
     steps:
       - uses: actions/checkout@v4
-      - uses: s4u/setup-maven-action@v1.11.0
-      - uses: coursier/cache-action@v6
+      - uses: actions/download-artifact@v4
         with:
-          root: ${{ matrix.component }}
-      - run: ./build.sh
-        working-directory: ${{ matrix.component }}
-  code-checks:
-    needs: build
-    strategy:
-      fail-fast: false
-      matrix:
-        component:
-          - utils
-          - client
-          - snapi-frontend
-          - snapi-truffle
-          - snapi-client
-          - python-client
-    runs-on: self-hosted
-    container:
-      image: ghcr.io/raw-labs/raw-scala-runner:buster_21.0.1.12-1_python3.7_scala2.12.18_sbt1.9.6
-      options: --user 1001
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.READ_PACKAGES }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: coursier/cache-action@v6
+          name: build
+          path: /home/sbtuser/.ivy2/local
+      - uses: actions/download-artifact@v4
         with:
-          root: ${{ matrix.component }}
+          name: versions
+          path: ./**/version
       - name: headers
         run: sbt headerCheckAll
         working-directory: ${{ matrix.component }}
@@ -122,9 +96,14 @@ jobs:
       - uses: oNaiPs/secrets-to-env-action@v1
         with:
           secrets: ${{ toJSON(secrets) }}
-      - uses: coursier/cache-action@v6
+      - uses: actions/download-artifact@v4
         with:
-          root: ${{ matrix.component }}
+          name: build
+          path: /home/sbtuser/.ivy2/local
+      - uses: actions/download-artifact@v4
+        with:
+          name: versions
+          path: ./**/version
       - run: sbt test
         working-directory: ${{ matrix.component }}
       - uses: mikepenz/action-junit-report@v3

--- a/client/project/Dependencies.scala
+++ b/client/project/Dependencies.scala
@@ -1,36 +1,8 @@
 import sbt._
-import java.nio.file.{Files, Paths}
 
 object Dependencies {
 
-  def findHighestVersionOfRawUtils(): String = {
-    val scalaBinaryVersion: String = scala.util.Properties.versionNumberString.split('.').take(2).mkString(".")
-
-    // Define the path to the Ivy cache for raw-utils
-    val ivyCachePath = Path.userHome / ".ivy2" / "local" / "com.raw-labs" / s"raw-utils_$scalaBinaryVersion"
-
-    // Check if the path exists and list all versions
-    if (ivyCachePath.exists) {
-      ivyCachePath.listFiles()
-        .filter(_.isDirectory)
-        .map(_.name)
-        .sorted
-        .lastOption
-        .getOrElse(throw new RuntimeException("No version found in Ivy cache for raw-utils"))
-    } else {
-      throw new RuntimeException("Ivy cache for raw-utils not found")
-    }
-  }
-
-  val rawUtilsVersion = {
-    val versionFilePath = "../utils/version"
-    if (Files.exists(Paths.get(versionFilePath))) {
-      IO.read(new File(versionFilePath)).trim
-    } else {
-      findHighestVersionOfRawUtils()
-    }
-  }
-
+  val rawUtilsVersion = IO.read(new File("../utils/version")).trim
   val rawUtils = "com.raw-labs" %% "raw-utils" % rawUtilsVersion
 
   val trufflePolyglot = "org.graalvm.polyglot" % "polyglot" % "23.1.0"

--- a/client/project/Dependencies.scala
+++ b/client/project/Dependencies.scala
@@ -1,8 +1,36 @@
 import sbt._
+import java.nio.file.{Files, Paths}
 
 object Dependencies {
 
-  val rawUtilsVersion = IO.read(new File("../utils/version")).trim
+  def findHighestVersionOfRawUtils(): String = {
+    val scalaBinaryVersion: String = scala.util.Properties.versionNumberString.split('.').take(2).mkString(".")
+
+    // Define the path to the Ivy cache for raw-utils
+    val ivyCachePath = Path.userHome / ".ivy2" / "local" / "com.raw-labs" / s"raw-utils_$scalaBinaryVersion"
+
+    // Check if the path exists and list all versions
+    if (ivyCachePath.exists) {
+      ivyCachePath.listFiles()
+        .filter(_.isDirectory)
+        .map(_.name)
+        .sorted
+        .lastOption
+        .getOrElse(throw new RuntimeException("No version found in Ivy cache for raw-utils"))
+    } else {
+      throw new RuntimeException("Ivy cache for raw-utils not found")
+    }
+  }
+
+  val rawUtilsVersion = {
+    val versionFilePath = "../utils/version"
+    if (Files.exists(Paths.get(versionFilePath))) {
+      IO.read(new File(versionFilePath)).trim
+    } else {
+      findHighestVersionOfRawUtils()
+    }
+  }
+
   val rawUtils = "com.raw-labs" %% "raw-utils" % rawUtilsVersion
 
   val trufflePolyglot = "org.graalvm.polyglot" % "polyglot" % "23.1.0"

--- a/snapi-client/test.sh
+++ b/snapi-client/test.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -ex
+SCRIPT_HOME="$(cd "$(dirname "$0")"; pwd)"
+[ "$CI" == "true" ] && { export HOME=/home/sbtuser; }
+. ~/.sdkman/bin/sdkman-init.sh
+
+yes | sdk install java 21-graalce || true
+sdk use java 21-graalce
+# snapi-frontend
+
+cd "${SCRIPT_HOME}"
+
+rm -rfv test-results
+mkdir -p test-results
+
+sbt test

--- a/snapi-frontend/test.sh
+++ b/snapi-frontend/test.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -ex
+SCRIPT_HOME="$(cd "$(dirname "$0")"; pwd)"
+[ "$CI" == "true" ] && { export HOME=/home/sbtuser; }
+. ~/.sdkman/bin/sdkman-init.sh
+
+yes | sdk install java 21-graalce || true
+sdk use java 21-graalce
+# snapi-frontend
+
+cd "${SCRIPT_HOME}"
+
+rm -rfv test-results
+mkdir -p test-results
+
+sbt test

--- a/tests.sh
+++ b/tests.sh
@@ -1,24 +1,14 @@
 #!/bin/bash -ex
 SCRIPT_HOME="$(cd "$(dirname "$0")"; pwd)"
-[ "$CI" == "true" ] && { export HOME=/home/sbtuser; }
-. ~/.sdkman/bin/sdkman-init.sh
 
-yes | sdk install java 21.0.1-graalce || true
-sdk use java 21-graalce
 # snapi-frontend
 
 cd "${SCRIPT_HOME}"/snapi-frontend
 
-rm -rfv test-results
-mkdir -p test-results
-
-sbt test
+./test.sh
 
 # snapi-client
 
 cd "${SCRIPT_HOME}"/snapi-client
 
-rm -rfv test-results
-mkdir -p test-results
-
-sbt test
+./test.sh


### PR DESCRIPTION
This PR is optimizing the CI runs.

We first build.
Then we start in parallel code checks and tests

Each of thos are also running parallel actions

(snapi-client tests are running meanwhile snapi-frontend tests are running somewhere else)
( each code checks for each component are running in parallel as well)

we use action artifacts in order to build once and then forward the local ivy cache with the produced artifacts

We might save 5  to 7 min on each run with those optimizations