### PR TITLE
RD-10265: UTF-8 character escape failing

### DIFF
--- a/snapi-client/src/test/scala/raw/compiler/rql2/tests/lsp/LspCommentsFormatTest.scala
+++ b/snapi-client/src/test/scala/raw/compiler/rql2/tests/lsp/LspCommentsFormatTest.scala
@@ -696,7 +696,7 @@ trait LspCommentsFormatTest extends CompilerTestContext {
         |                in
         |                    {
         |                        machineId: Int.From(List.Get(groups, 1)),
-        |                        timestamp: Timestamp.Parse(List.Get(groups, 0), "y-M-d\'T\'H:m:s"),
+        |                        timestamp: Timestamp.Parse(List.Get(groups, 0), "y-M-d'T'H:m:s"),
         |                        error: List.Get(groups, 2)
         |                    }
         |        )
@@ -928,5 +928,11 @@ trait LspCommentsFormatTest extends CompilerTestContext {
         |    Collection.First(points)""".stripMargin
     )
   }
+
+  test("\"x\\u2192x+1\" // RD-10265")(it => assertFormattedCode(it.q, "\"x\\u2192x+1\" // RD-10265"))
+
+  test("\"x\u2192x+1\" // RD-10265")(it => assertFormattedCode(it.q, "\"x\\u2192x+1\" // RD-10265"))
+
+  test("\"\"\"x\u2192x+1\"\"\" // RD-10265")(it => assertFormattedCode(it.q, "\"\"\"x\u2192x+1\"\"\" // RD-10265"))
 
 }

--- a/snapi-client/src/test/scala/raw/compiler/rql2/tests/spec/ConstTest.scala
+++ b/snapi-client/src/test/scala/raw/compiler/rql2/tests/spec/ConstTest.scala
@@ -31,13 +31,21 @@ trait ConstTest extends CompilerTestContext with TableDrivenPropertyChecks {
     it should evaluateTo(""""Hello"""")
   }
 
+  test("\"x\\u2192x+1\" // RD-10265") { it =>
+    it should parse
+    it should typeAs("string")
+    it should astTypeAs(Rql2StringType())
+    it should run
+    it should evaluateTo(""""x\u2192x+1"""")
+  }
+
   test("""  true """) { it =>
     it should typeAs("bool")
     it should astTypeAs(Rql2BoolType())
     it should evaluateTo("""true""")
   }
 
-  val consts = Table(
+  private val consts = Table(
     "constants",
     TestValue("byte", "1b"),
     TestValue("short", "Short.From(1)"),

--- a/snapi-client/src/test/scala/raw/compiler/rql2/tests/spec/ConstTest.scala
+++ b/snapi-client/src/test/scala/raw/compiler/rql2/tests/spec/ConstTest.scala
@@ -32,6 +32,26 @@ trait ConstTest extends CompilerTestContext with TableDrivenPropertyChecks {
   }
 
   test("\"x\\u2192x+1\" // RD-10265") { it =>
+    // The source code contains the escaped unicode character. It should parse and run as if the character
+    // was in the source code.
+    it should parse
+    it should typeAs("string")
+    it should astTypeAs(Rql2StringType())
+    it should run
+    it should evaluateTo(""""x\u2192x+1"""")
+  }
+
+  test("\"x\u2192x+1\" // RD-10265") { it =>
+    // The source code contains the unicode character. It should parse and run.
+    it should parse
+    it should typeAs("string")
+    it should astTypeAs(Rql2StringType())
+    it should run
+    it should evaluateTo(""""x\u2192x+1"""")
+  }
+
+  test("\"\"\"x\u2192x+1\"\"\"// RD-10265") { it =>
+    // The source code is using triple quoted string, it can contain the unicode character
     it should parse
     it should typeAs("string")
     it should astTypeAs(Rql2StringType())

--- a/utils/build.sbt
+++ b/utils/build.sbt
@@ -151,6 +151,7 @@ libraryDependencies ++= Seq(
   typesafeConfig,
   loki4jAppender,
   commonsIO,
+  commonsText,
   scalatest % Test
 ) ++
   slf4j ++

--- a/utils/project/Dependencies.scala
+++ b/utils/project/Dependencies.scala
@@ -21,6 +21,7 @@ object Dependencies {
   val loki4jAppender = "com.github.loki4j" % "loki-logback-appender" % "1.4.2"
 
   val commonsIO = "commons-io" % "commons-io" % "2.11.0"
+  val commonsText = "org.apache.commons" % "commons-text" % "1.11.0"
 
   val commonsCodec = "commons-codec" % "commons-codec" % "1.16.0"
 

--- a/utils/src/main/java/module-info.java
+++ b/utils/src/main/java/module-info.java
@@ -17,6 +17,7 @@ module raw.utils {
   requires com.fasterxml.jackson.dataformat.csv;
   requires com.fasterxml.jackson.scala;
   requires org.apache.commons.io;
+  requires org.apache.commons.text;
   requires typesafe.config;
   requires typesafe.scalalogging;
   requires org.slf4j;

--- a/utils/src/main/scala/raw/utils/RawUtils.scala
+++ b/utils/src/main/scala/raw/utils/RawUtils.scala
@@ -28,6 +28,7 @@ import java.util.zip.ZipFile
 
 import scala.util.control.NonFatal
 import scala.collection.JavaConverters._
+import org.apache.commons.text.StringEscapeUtils
 
 object RawUtils extends StrictLogging {
 
@@ -35,51 +36,10 @@ object RawUtils extends StrictLogging {
    * Convert a user string back to its original "intended" representation.
    * e.g. if the user types "\t" we get the a single '\t' char out instead of the two byte string "\t".
    */
-  def escape(s: String): String = {
-    var escapedStr = ""
-    var escape = false
-    for (c <- s) {
-      if (!escape) {
-        if (c == '\\') {
-          escape = true
-        } else {
-          escapedStr += c
-        }
-      } else {
-        escapedStr += (c match {
-          case '\\' => '\\'
-          case '\'' => '\''
-          case '"' => '"'
-          case 'b' => '\b'
-          case 'f' => '\f'
-          case 'n' => '\n'
-          case 'r' => '\r'
-          case 't' => '\t'
-        })
-        escape = false
-      }
-    }
-    escapedStr
-  }
+  def escape(s: String): String = StringEscapeUtils.unescapeJava(s)
 
   /** Does the opposite of the method `escape`. */
-  def descape(s: String): String = {
-    var descapedStr = ""
-    for (c <- s) {
-      descapedStr += (c match {
-        case '\\' => "\\\\"
-        case '\'' => "\\'"
-        case '\"' => "\\\""
-        case '\b' => "\\b"
-        case '\f' => "\\f"
-        case '\n' => "\\n"
-        case '\r' => "\\r"
-        case '\t' => "\\t"
-        case _ => c
-      })
-    }
-    descapedStr
-  }
+  def descape(s: String): String = StringEscapeUtils.escapeJava(s)
 
   def readEntireFile(path: Path, charset: Charset = StandardCharsets.UTF_8): String = {
     new String(Files.readAllBytes(path), charset)


### PR DESCRIPTION
Note that this patch is _adding_ a dependency to `org.apache.commons.text` that has a utility performing the string escapes we need. Our `RawUtils.escape`/`descape` do not support dealing with UTF-8 escapes.