### PR TITLE
fix(snapi-parser)(build): misc

### DIFF
--- a/snapi-parser/build.sbt
+++ b/snapi-parser/build.sbt
@@ -14,7 +14,7 @@ sonatypeRepository := "https://s01.oss.sonatype.org/service/local"
 
 sonatypeProfileName := "com.raw-labs"
 
-val licenseHeader = s"""Copyright ${Year.now.getValue} RAW Labs S.A.
+val licenseHeader = """Copyright 2023 RAW Labs S.A.
 
 Use of this software is governed by the Business Source License
 included in the file licenses/BSL.txt.

--- a/snapi-parser/build.sbt
+++ b/snapi-parser/build.sbt
@@ -190,3 +190,4 @@ Compile / compile := (Compile / compile).dependsOn(generateParser).value
 
 publishLocal := (publishLocal dependsOn Def.sequential(outputVersion, generateParser, publishM2)).value
 publish := (publish dependsOn Def.sequential(outputVersion, generateParser, publishM2)).value
+publishSigned := (publishSigned dependsOn Def.sequential(outputVersion, generateParser, publishM2)).value


### PR DESCRIPTION
When publishing a release version we do `publishSigned`  so this sbt task needs to follow the same flow  as `publish`  and `publishLocal`