### PR TITLE
fix(snapi-truffle)(cd): publish tasks shoudl depend on runJavaAnnotationProcessor

### DIFF
--- a/snapi-truffle/build.sbt
+++ b/snapi-truffle/build.sbt
@@ -193,8 +193,6 @@ resolvers += Resolver.sonatypeRepo("releases")
 // Publish settings
 Test / publishArtifact := true
 Compile / packageSrc / publishArtifact := true
-// When doing publishLocal, also publish to the local maven repository.
-publishLocal := (publishLocal dependsOn publishM2).value
 
 // Dependencies
 libraryDependencies ++= Seq(
@@ -220,3 +218,7 @@ outputVersion := {
 }
 
 Compile / compile := ((Compile / compile) dependsOn outputVersion).value
+
+publishLocal := (publishLocal dependsOn Def.sequential(runJavaAnnotationProcessor, outputVersion, publishM2)).value
+publish := (publish dependsOn Def.sequential(runJavaAnnotationProcessor, outputVersion)).value
+publishSigned := (publishSigned dependsOn Def.sequential(runJavaAnnotationProcessor, outputVersion)).value

--- a/snapi-truffle/build.sbt
+++ b/snapi-truffle/build.sbt
@@ -6,6 +6,8 @@ import Dependencies.*
 
 import scala.sys.process.Process
 
+import com.jsuereth.sbtpgp.PgpKeys.{publishSigned}
+
 ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org"
 
 sonatypeRepository := "https://s01.oss.sonatype.org/service/local"

--- a/snapi-truffle/build.sh
+++ b/snapi-truffle/build.sh
@@ -7,4 +7,4 @@ yes | sdk install java 21.0.1-graalce || true
 sdk use java 21.0.1-graalce
 
 cd "$SCRIPT_HOME"
-sbt clean runJavaAnnotationProcessor publishLocal
+sbt clean publishLocal


### PR DESCRIPTION
We make sure to run `runJavaAnnotationProcessor` task before compiling/publishing