### PR TITLE
RD-10538: Nullable columns sometimes reported as non-nullable

### DIFF
--- a/sql-client/src/main/scala/raw/client/sql/NamedParametersPreparedStatement.scala
+++ b/sql-client/src/main/scala/raw/client/sql/NamedParametersPreparedStatement.scala
@@ -178,7 +178,9 @@ class NamedParametersPreparedStatement(conn: Connection, code: String) extends S
       val name = metadata.getColumnName(i)
       val typeInfo = {
         val tipe = metadata.getColumnType(i)
-        val nullable = metadata.isNullable(i) == ResultSetMetaData.columnNullable
+        val nullability = metadata.isNullable(i)
+        val nullable =
+          nullability == ResultSetMetaData.columnNullable || nullability == ResultSetMetaData.columnNullableUnknown
         SqlTypesUtils.rawTypeFromJdbc(tipe).right.map {
           case t: RawAnyType => t
           case t: RawType => t.cloneWithFlags(nullable, false)

--- a/sql-client/src/test/scala/raw/client/sql/TestSqlCompilerServiceAirports.scala
+++ b/sql-client/src/test/scala/raw/client/sql/TestSqlCompilerServiceAirports.scala
@@ -274,9 +274,9 @@ class TestSqlCompilerServiceAirports extends RawTestSuite with SettingsTestConte
       |    "country": "Portugal",
       |    "iata_faa": "BGC",
       |    "icao": "LPBG",
-      |    "latitude": "41.857800",
-      |    "longitude": "-6.707125",
-      |    "altitude": "2241.000",
+      |    "latitude": 41.857800,
+      |    "longitude": -6.707125,
+      |    "altitude": 2241.000,
       |    "timezone": 0,
       |    "dst": "E",
       |    "tz": "Europe/Lisbon"

--- a/sql-client/src/test/scala/raw/client/sql/TestSqlCompilerServiceAirports.scala
+++ b/sql-client/src/test/scala/raw/client/sql/TestSqlCompilerServiceAirports.scala
@@ -473,7 +473,7 @@ class TestSqlCompilerServiceAirports extends RawTestSuite with SettingsTestConte
     val List(main) = description.decls("main")
     assert(
       main.outType == RawIterableType(
-        RawRecordType(Vector(RawAttrType("count", RawLongType(false, false))), false, false),
+        RawRecordType(Vector(RawAttrType("count", RawLongType(true, false))), false, false),
         false,
         false
       )
@@ -519,7 +519,7 @@ class TestSqlCompilerServiceAirports extends RawTestSuite with SettingsTestConte
     val List(main) = description.decls("main")
     assert(
       main.outType == RawIterableType(
-        RawRecordType(Vector(RawAttrType("count", RawLongType(false, false))), false, false),
+        RawRecordType(Vector(RawAttrType("count", RawLongType(true, false))), false, false),
         false,
         false
       )
@@ -537,4 +537,44 @@ class TestSqlCompilerServiceAirports extends RawTestSuite with SettingsTestConte
     assert(compilerService.execute(t.q, withNull, None, baos) == ExecutionSuccess)
     assert(baos.toString() == """[{"count":3}]""")
   }
+
+  test("""SELECT DATE '2002-01-01' - :s::int AS x -- RD-10538""") { t =>
+    assume(password != "")
+
+    val environment = ProgramEnvironment(user, None, Set.empty, Map("output-format" -> "json"))
+    val v = compilerService.validate(t.q, environment)
+    assert(v.errors.isEmpty)
+    val GetProgramDescriptionSuccess(description) = compilerService.getProgramDescription(t.q, environment)
+    assert(description.maybeType.isEmpty)
+    val List(main) = description.decls("main")
+    assert(
+      main.outType == RawIterableType(
+        RawRecordType(
+          Vector(
+            RawAttrType("x", RawDateType(true, false))
+          ),
+          false,
+          false
+        ),
+        false,
+        false
+      )
+    )
+    assert(main.params.contains(Vector(ParamDescription("s", RawIntType(true, false), Some(RawNull()), false))))
+    val baos = new ByteArrayOutputStream()
+    assert(
+      compilerService.execute(
+        t.q,
+        environment,
+        None,
+        baos
+      ) == ExecutionSuccess
+    )
+    assert(baos.toString() == """[
+      |  {
+      |    "x": null
+      |  }
+      |]""".stripMargin.replaceAll("\\s+", ""))
+  }
+
 }


### PR DESCRIPTION
The code didn't check if the status was 'unknown' (in which case, we should make it nullable).

A test was added that reports a column has unknown nullability.

An existing test had to be fixed since we were asserting its output had a certain nullability. Since we changed the code, the nullability of its column changed.

Also, an existing test was still assuming decimals were surrounded with double quotes (which was the case before RD-10527 got fixed).