### PR TITLE
RD-10004 improve-error-propagation-for-lsp-in-the-compiler-interfaces

### DIFF
--- a/client/src/main/scala/raw/client/api/CompilerService.scala
+++ b/client/src/main/scala/raw/client/api/CompilerService.scala
@@ -330,7 +330,7 @@ final case class FormatCodeResponse(code: Option[String]) extends ClientLspRespo
 final case class HoverResponse(completion: Option[Completion]) extends ClientLspResponse
 final case class RenameResponse(positions: Array[Pos]) extends ClientLspResponse
 final case class GoToDefinitionResponse(position: Option[Pos]) extends ClientLspResponse
-final case class ValidateResponse(errors: List[ErrorMessage]) extends ClientLspResponse
+final case class ValidateResponse(errors: List[Message]) extends ClientLspResponse
 final case class ErrorResponse(errors: List[ErrorMessage]) extends ClientLspResponse
 final case class AutoCompleteResponse(completions: Array[Completion]) extends ClientLspResponse
 

--- a/client/src/main/scala/raw/client/api/Errors.scala
+++ b/client/src/main/scala/raw/client/api/Errors.scala
@@ -18,8 +18,17 @@ import raw.utils.RawException
  * Used for errors that are found during semantic analysis.
  * @param message The error message.
  * @param positions The positions where the error occurred.
+ * @param severity The severity of the error. 1 = Hint, 2 = Info, 4 = Warning, 8 = Error
+ * @param code An optional error code.
+ * @param tags Indication for the error Unnecessary = 1, Deprecated = 2
  */
-final case class ErrorMessage(message: String, positions: List[ErrorRange])
+final case class ErrorMessage(
+    message: String,
+    positions: List[ErrorRange],
+    severity: Int = 8,
+    code: Option[String] = None,
+    tags: List[Integer] = List.empty
+)
 final case class ErrorRange(begin: ErrorPosition, end: ErrorPosition)
 final case class ErrorPosition(line: Int, column: Int)
 

--- a/client/src/main/scala/raw/client/api/Errors.scala
+++ b/client/src/main/scala/raw/client/api/Errors.scala
@@ -59,8 +59,6 @@ sealed trait Tag {
 final case class UnnecessaryTag(tagNumber: Int = 1) extends Tag
 final case class DeprecatedTag(tagNumber: Int = 2) extends Tag
 
-
-
 final case class ErrorRange(begin: ErrorPosition, end: ErrorPosition)
 final case class ErrorPosition(line: Int, column: Int)
 

--- a/client/src/main/scala/raw/client/api/Errors.scala
+++ b/client/src/main/scala/raw/client/api/Errors.scala
@@ -12,23 +12,55 @@
 
 package raw.client.api
 
+import com.fasterxml.jackson.annotation.{JsonSubTypes, JsonTypeInfo}
 import raw.utils.RawException
+import com.fasterxml.jackson.annotation.JsonSubTypes.{Type => JsonType}
 
 /**
  * Used for errors that are found during semantic analysis.
- * @param message The error message.
- * @param positions The positions where the error occurred.
- * @param severity The severity of the error. 1 = Hint, 2 = Info, 4 = Warning, 8 = Error
- * @param code An optional error code.
- * @param tags Indication for the error Unnecessary = 1, Deprecated = 2
+ * message The error message.
+ * positions The positions where the error occurred.
+ * severity The severity of the error. 1 = Hint, 2 = Info, 4 = Warning, 8 = Error
+ * code An optional error code.
+ * tags Indication for the error Unnecessary = 1, Deprecated = 2
  */
-final case class ErrorMessage(
-    message: String,
-    positions: List[ErrorRange],
-    severity: Int = 8,
-    code: Option[String] = None,
-    tags: List[Integer] = List.empty
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonSubTypes(
+  Array(
+    new JsonType(value = classOf[HintMessage], name = "hint"),
+    new JsonType(value = classOf[InfoMessage], name = "info"),
+    new JsonType(value = classOf[WarningMessage], name = "warning"),
+    new JsonType(value = classOf[ErrorMessage], name = "hint")
+  )
 )
+sealed trait Message {
+  def message: String
+  def positions: List[ErrorRange]
+  def severity: Int
+  def code: Option[String] = None
+  def tags: List[Tag] = List.empty
+}
+final case class HintMessage(message: String, positions: List[ErrorRange], severity: Int = 1) extends Message
+final case class InfoMessage(message: String, positions: List[ErrorRange], severity: Int = 2) extends Message
+final case class WarningMessage(message: String, positions: List[ErrorRange], severity: Int = 4) extends Message
+final case class ErrorMessage(message: String, positions: List[ErrorRange], severity: Int = 8) extends Message
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonSubTypes(
+  Array(
+    new JsonType(value = classOf[UnnecessaryTag], name = "unnecessary"),
+    new JsonType(value = classOf[DeprecatedTag], name = "deprecated")
+  )
+)
+sealed trait Tag {
+  def tagNumber: Int
+}
+final case class UnnecessaryTag(tagNumber: Int = 1) extends Tag
+final case class DeprecatedTag(tagNumber: Int = 2) extends Tag
+
+
+
 final case class ErrorRange(begin: ErrorPosition, end: ErrorPosition)
 final case class ErrorPosition(line: Int, column: Int)
 

--- a/client/src/main/scala/raw/client/api/Errors.scala
+++ b/client/src/main/scala/raw/client/api/Errors.scala
@@ -20,9 +20,9 @@ import com.fasterxml.jackson.annotation.JsonSubTypes.{Type => JsonType}
  * Used for errors that are found during semantic analysis.
  * message The error message.
  * positions The positions where the error occurred.
- * severity The severity of the error. 1 = Hint, 2 = Info, 4 = Warning, 8 = Error
+ * severity The severity of the error. 1 = Hint, 2 = Info, 4 = Warning, 8 = Error (compliant with monaco editor).
  * code An optional error code.
- * tags Indication for the error Unnecessary = 1, Deprecated = 2
+ * tags Indication for the error Unnecessary = 1, Deprecated = 2 (compliant with monaco editor).
  */
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
@@ -35,17 +35,44 @@ import com.fasterxml.jackson.annotation.JsonSubTypes.{Type => JsonType}
   )
 )
 sealed trait Message {
-  def message: String
-  def positions: List[ErrorRange]
-  def severity: Int
-  def code: Option[String] = None
-  def tags: List[Tag] = List.empty
+  val message: String
+  val positions: List[ErrorRange]
+  val code: Option[String]
+  val tags: List[Tag]
+  val severity: Int
 }
-final case class HintMessage(message: String, positions: List[ErrorRange], severity: Int = 1) extends Message
-final case class InfoMessage(message: String, positions: List[ErrorRange], severity: Int = 2) extends Message
-final case class WarningMessage(message: String, positions: List[ErrorRange], severity: Int = 4) extends Message
-final case class ErrorMessage(message: String, positions: List[ErrorRange], severity: Int = 8) extends Message
-
+final case class HintMessage(
+    message: String,
+    positions: List[ErrorRange],
+    code: Option[String] = None,
+    tags: List[Tag] = List.empty
+) extends Message {
+  val severity: Int = 1
+}
+final case class InfoMessage(
+    message: String,
+    positions: List[ErrorRange],
+    code: Option[String] = None,
+    tags: List[Tag] = List.empty
+) extends Message {
+  val severity: Int = 2
+}
+final case class WarningMessage(
+    message: String,
+    positions: List[ErrorRange],
+    code: Option[String] = None,
+    tags: List[Tag] = List.empty
+) extends Message {
+  val severity: Int = 4
+}
+final case class ErrorMessage(
+    message: String,
+    positions: List[ErrorRange],
+    code: Option[String] = None,
+    tags: List[Tag] = List.empty
+) extends Message {
+  val severity: Int = 8
+}
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 @JsonSubTypes(
   Array(
@@ -54,10 +81,14 @@ final case class ErrorMessage(message: String, positions: List[ErrorRange], seve
   )
 )
 sealed trait Tag {
-  def tagNumber: Int
+  val tagNumber: Int
 }
-final case class UnnecessaryTag(tagNumber: Int = 1) extends Tag
-final case class DeprecatedTag(tagNumber: Int = 2) extends Tag
+final case class UnnecessaryTag() extends Tag {
+  val tagNumber: Int = 1
+}
+final case class DeprecatedTag() extends Tag {
+  val tagNumber: Int = 2
+}
 
 final case class ErrorRange(begin: ErrorPosition, end: ErrorPosition)
 final case class ErrorPosition(line: Int, column: Int)


### PR DESCRIPTION
Updated Errors class, added:
- code as a type of error message
- tags (deprecated etc..)
- severity 

These information is corespondent to what monaco editor expects