### PR TITLE
Fixed RD-10593 and RD-10594

### DIFF
--- a/snapi-frontend/src/main/scala/raw/compiler/rql2/builtin/CsvPackage.scala
+++ b/snapi-frontend/src/main/scala/raw/compiler/rql2/builtin/CsvPackage.scala
@@ -51,6 +51,7 @@ object CsvPackage extends CsvPackage {
       case Rql2ListType(rType: Rql2RecordType, iProps) =>
         if (iProps.nonEmpty) return false;
         rType
+      case _ => return false
     }
     if (innerRecordType.props.nonEmpty) return false;
 

--- a/snapi-frontend/src/main/scala/raw/compiler/rql2/source/SourcePrettyPrinter.scala
+++ b/snapi-frontend/src/main/scala/raw/compiler/rql2/source/SourcePrettyPrinter.scala
@@ -58,7 +58,7 @@ trait SourcePrettyPrinter
           d
         }
       case FunType(ms, os, r, props) =>
-        val args = ms.map(toDoc) ++ os.map(o => o.i <> ":" <+> o.t)
+        val args = ms.map(toDoc) ++ os.map(o => ident(o.i) <> ":" <+> o.t)
         val d = parens(enclosedList(args)) <+> "->" <+> r
         if (internal && props.nonEmpty) {
           // Wrap in parenthesis to disambiguate the type property annotations.

--- a/snapi-frontend/src/test/scala/raw/compiler/rql2/Antlr4TypeTests.scala
+++ b/snapi-frontend/src/test/scala/raw/compiler/rql2/Antlr4TypeTests.scala
@@ -297,4 +297,5 @@ class Antlr4TypeTests extends RawTestSuite {
         )
     )
   }
+
 }


### PR DESCRIPTION
* RD-10594: function parameter names aren't quote when needed
* RD-10593: `CsvPackage.outputWriteSupport` is crashing if passed a random type that isn't a collection or a list.