### PR TITLE
refactor(deps)(others)(build): improve jar path retrieval

### DIFF
--- a/deps/kiama/build.sbt
+++ b/deps/kiama/build.sbt
@@ -173,6 +173,8 @@ val noPublishSettings =
 
 val extrasProject = ProjectRef(file("."), "extras")
 
+val isRelease = sys.props.getOrElse("release", "false").toBoolean
+
 lazy val core =
     setupSubProject(
         project in file("core"),
@@ -204,7 +206,8 @@ lazy val core =
         TestScalaUnidoc/unidoc/unidocProjectFilter := (ScalaUnidoc/unidoc/unidocProjectFilter).value,
 
         Compile / packageBin / packageOptions += Package.ManifestAttributes( "Automatic-Module-Name" -> "kiama"),
-        publishLocal := (publishLocal dependsOn publishM2).value
+        publishLocal := (publishLocal dependsOn publishM2).value,
+        isSnapshot := !isRelease
     )
 
 lazy val extras =

--- a/deps/others/build.sbt
+++ b/deps/others/build.sbt
@@ -28,38 +28,6 @@ val moduleNames = Map(
   "mysql-connector-j" -> "mysql.connector.j",
 )
 
-def getCoursierCachePath: String = {
-  // Standard path
-  val standardPath = sys.props("user.home") + "/.cache/coursier/v1"
-
-  // Check if the standard path exists
-  if (Files.exists(Paths.get(standardPath))) {
-    standardPath
-  } else {
-    // Check for a custom path in an environment variable
-    val envVar = "COURSIER_CACHE"
-    sys.env.get(envVar) match {
-      case Some(customPath) =>
-        if (Files.exists(Paths.get(customPath))) {
-          customPath
-        } else {
-          throw new IllegalStateException(s"Custom Coursier cache path specified in $envVar does not exist: $customPath")
-        }
-      case None =>
-        throw new IllegalStateException(s"Coursier cache path not found at $standardPath and no custom path specified in $envVar.")
-    }
-  }
-}
-
-def locateOriginalPom(groupID: String, artifactID: String, version: String): File = {
-  val coursierCachePath = getCoursierCachePath
-  // Convert groupID to URL-like structure (e.g., "com.fasterxml.jackson.module" to "com/fasterxml/jackson/module")
-  val groupPath = groupID.replaceAll("\\.", "/")
-  // Construct the path to the POM in the Coursier cache
-  val pomPath = s"$coursierCachePath/https/repo1.maven.org/maven2/$groupPath/$artifactID/$version/$artifactID-$version.pom"
-  new File(pomPath)
-}
-
 def updatePom(pomFile: File, newVersion: String): Unit = {
   val pomXml = XML.loadFile(pomFile)
 
@@ -98,72 +66,68 @@ def updatePom(pomFile: File, newVersion: String): Unit = {
 val patchDependencies = taskKey[Unit]("Patch dependencies")
 
 patchDependencies := {
-  (update.value) // Make sure update task is run before patchDependencies task
   val log = streams.value.log
   val updateReport = update.value
 
-  // Obtain map of path to  groupID, artifactID, veresion for all dependency
-  val jars = updateReport.configurations.flatMap(_.modules).map { module =>
-    val id = module.module
-    val groupID = id.organization
-    val artifactID = id.name
-    val version = id.revision
+  updateReport.configurations.flatMap(_.modules).distinct.foreach { module =>
+    val groupID = module.module.organization
+    val artifactID = module.module.name
+    val version = module.module.revision
+    val scalaVersionSuffixPattern = "_2\\.\\d{1,2}".r
+    val normalizedArtifactId = scalaVersionSuffixPattern.replaceFirstIn(artifactID, "")
+    if (moduleNames.contains(normalizedArtifactId)) {
+      log.info(s"Found module $artifactID:$version")
+      module.artifacts.find(_._1.extension == "jar").foreach { case (_, jarFile) =>
+        try {
+          val pomPath = jarFile.getAbsolutePath.replace(".jar", ".pom")
+          val pomFile = new File(pomPath)
+          if (!pomFile.exists()) {
+            log.error(s"Expected POM file does not exist for $artifactID:$version at $pomPath")
+          } else {
+            log.info(s"Found POM file for $artifactID:$version at $pomPath")
 
-    // Obtain the path to the JAR file
-    val path = module.artifacts.head._2
+            val newName = jarFile.getName.replace(".jar", "-rawlabs.jar")
+            val newJarFile = new File(jarFile.getParent, newName)
+            Files.copy(jarFile.toPath, newJarFile.toPath, StandardCopyOption.REPLACE_EXISTING)
+            log.info(s"Patched JAR file created: $newName")
 
-    // Create a key-value pair with the module name as the key and the groupID and artifactID as the value
-    (path -> (groupID, artifactID, version))
-  }.toMap
+            // Handling the manifest
+            val manifest = new File("manifest.txt")
+            val bw = new BufferedWriter(new FileWriter(manifest))
+            try {
+              bw.write(s"Automatic-Module-Name: ${moduleNames(normalizedArtifactId)}\n")
+            } finally {
+              bw.close()
+            }
 
-  // Filter out all JAR files that are in the map of module names
-  val jarsToPatch = jars
-    .filter { case (jar, _) =>
-      val path = jar.getAbsolutePath
+            // Update the JAR file with the new manifest
+            val patchCommand = s"jar --update --file ${newJarFile.getAbsolutePath} --manifest=manifest.txt"
+            val patchExitCode = patchCommand.!
+            if (patchExitCode == 0) {
+              log.info(s"JAR file $newName patched successfully with new manifest.")
+            } else {
+              log.error(s"Failed to patch JAR file $newName with new manifest.")
+            }
 
-      // Make sure path matches one of the moduleName keys
-      moduleNames.keys.exists(path.contains)
-    }
-    
-  // Patch all JARs that need to be patched
-  jarsToPatch
-    .foreach { case (jar, (groupID, artifactID, version)) =>
-    val path = jar.getAbsolutePath  
+            // Update and publish the POM file
+            updatePom(pomFile, version)
+            val copiedPomFile = new File(pomFile.getParent, s"$artifactID-$version-rawlabs.pom")
+            Files.copy(pomFile.toPath, copiedPomFile.toPath, StandardCopyOption.REPLACE_EXISTING)
+            log.info(s"Updated POM file for $artifactID with version $version-rawlabs")
 
-    // Get the name of the JAR file
-    val name = jar.getName
-    val newName = name.replace(".jar", "-rawlabs.jar")
-    // Copy the JAR file to a new JAR file with the same name but with the suffix '-rawlabs'
-    val newJar = new File(newName)
-    Files.copy(jar.toPath, newJar.toPath, StandardCopyOption.REPLACE_EXISTING)
-
-    // Create a file called manifest.txt and add 'Automatic-Module-Name: sdk.http.ahc'
-    val manifest = new File("manifest.txt")
-    val bw = new BufferedWriter(new FileWriter(manifest))
-    bw.write(s"Automatic-Module-Name: ${moduleNames.find { case (k, v) => path.contains(k) }.get._2}\n")
-    bw.close()
-
-    // Patch the new JAR file with jar --update --file <jar> --manifest=manifest.txt
-    // Check that patching was successful
-    val patch = s"jar --update --file $newJar --manifest=manifest.txt"
-    val patchExitCode = patch.!
-    if (patchExitCode != 0) {
-      throw new Exception(s"Failed to patch JAR $newJar")
-    }
-
-    // Locate and copy the original pom.xml
-    val originalPom = locateOriginalPom(groupID, artifactID, version) // Implement this function
-    val copiedPom = new File(originalPom.getParent, s"$artifactID-$version-rawlabs.pom")
-    Files.copy(originalPom.toPath, copiedPom.toPath, StandardCopyOption.REPLACE_EXISTING)
-
-    // Modify the copied pom.xml
-    updatePom(copiedPom, version)
-
-    // Publish the patched JAR file to the local Maven repository
-    val publish = s"mvn install:install-file -Dfile=$newJar -DpomFile=${copiedPom.getAbsolutePath} -DgroupId=$groupID -DartifactId=$artifactID -Dversion=$version-rawlabs -Dpackaging=jar"
-    val publishExitCode = publish.!
-    if (publishExitCode != 0) {
-      throw new Exception(s"Failed to publish JAR $newJar")
+            val publishCommand = s"mvn install:install-file -Dfile=${newJarFile.getAbsolutePath} -DpomFile=${copiedPomFile.getAbsolutePath} -DgroupId=$groupID -DartifactId=$artifactID -Dversion=$version-rawlabs -Dpackaging=jar"
+            val publishExitCode = publishCommand.!
+            if (publishExitCode == 0) {
+              log.info(s"Published patched JAR $newName with updated POM $artifactID-$version-rawlabs.")
+            } else {
+              log.error(s"Failed to publish JAR $newName and POM $artifactID-$version-rawlabs.")
+            }
+          }
+        } catch {
+          case e: Exception =>
+            log.error(s"Error during the patching process for $artifactID:$version: ${e.getMessage}")
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
- Stop try to locate only coursier cache, just use the `update.value` infos
- allow to re-publish locally kiama