### PR TITLE
RD-10539 SELECT :v ::interval AS column fails with internal error

### DIFF
--- a/sql-client/src/main/scala/raw/client/sql/NamedParametersPreparedStatement.scala
+++ b/sql-client/src/main/scala/raw/client/sql/NamedParametersPreparedStatement.scala
@@ -101,16 +101,17 @@ class NamedParametersPreparedStatement(conn: Connection, code: String)(implicit 
     plainCodeBuffer.toString()
   }
 
-  private def validateParameterType(tipe: RawType, name: String, typeName: String): Either[String, RawType] = tipe match {
-    case _: RawNumberType => Right(tipe)
-    case _: RawStringType => Right(tipe)
-    case _: RawBoolType => Right(tipe)
-    case _: RawDateType => Right(tipe)
-    case _: RawTimeType => Right(tipe)
-    case _: RawTimestampType => Right(tipe)
-    case _: RawBinaryType => Right(tipe)
-    case _ => Left(s"parameter '$name' has an unsupported type '$typeName'")
-  }
+  private def validateParameterType(tipe: RawType, name: String, typeName: String): Either[String, RawType] =
+    tipe match {
+      case _: RawNumberType => Right(tipe)
+      case _: RawStringType => Right(tipe)
+      case _: RawBoolType => Right(tipe)
+      case _: RawDateType => Right(tipe)
+      case _: RawTimeType => Right(tipe)
+      case _: RawTimestampType => Right(tipe)
+      case _: RawBinaryType => Right(tipe)
+      case _ => Left(s"parameter '$name' has an unsupported type '$typeName'")
+    }
   // A data structure for the full query info: parameters that are mapped to their inferred types, and output type (the query type)
   case class QueryInfo(parameters: Map[String, RawType], outputType: RawType)
 

--- a/sql-client/src/main/scala/raw/client/sql/NamedParametersPreparedStatement.scala
+++ b/sql-client/src/main/scala/raw/client/sql/NamedParametersPreparedStatement.scala
@@ -101,7 +101,7 @@ class NamedParametersPreparedStatement(conn: Connection, code: String)(implicit 
     plainCodeBuffer.toString()
   }
 
-  private def validateParameterType(tipe: RawType): Either[String, RawType] = tipe match {
+  private def validateParameterType(tipe: RawType, name: String, typeName: String): Either[String, RawType] = tipe match {
     case _: RawNumberType => Right(tipe)
     case _: RawStringType => Right(tipe)
     case _: RawBoolType => Right(tipe)
@@ -109,8 +109,7 @@ class NamedParametersPreparedStatement(conn: Connection, code: String)(implicit 
     case _: RawTimeType => Right(tipe)
     case _: RawTimestampType => Right(tipe)
     case _: RawBinaryType => Right(tipe)
-    case _ => Left(s"Unsupported parameter type: $tipe")
-
+    case _ => Left(s"parameter '$name' has an unsupported type '$typeName'")
   }
   // A data structure for the full query info: parameters that are mapped to their inferred types, and output type (the query type)
   case class QueryInfo(parameters: Map[String, RawType], outputType: RawType)
@@ -133,7 +132,7 @@ class NamedParametersPreparedStatement(conn: Connection, code: String)(implicit 
               metadata.getParameterType(location.index),
               metadata.getParameterTypeName(location.index)
             ) match {
-              case Right(t) => validateParameterType(t)
+              case Right(t) => validateParameterType(t, p, metadata.getParameterTypeName(location.index))
               case Left(error) => Left(error)
             }
           )

--- a/sql-client/src/main/scala/raw/client/sql/SqlIntervals.scala
+++ b/sql-client/src/main/scala/raw/client/sql/SqlIntervals.scala
@@ -1,0 +1,64 @@
+package raw.client.sql
+
+import raw.client.api.RawInterval
+
+import scala.util.matching.Regex
+
+object SqlIntervals {
+
+  val postgresIntervalRegex: Regex =
+    """(?:(\d+)\s+years?)?(?:\s*(\d+) mons?)?(?:\s*(\d+) days?)?(?:\s*(\d+):(\d+):(\d+)(?:\.(\d+))?)?""".r
+
+  def padRight(s: String, n: Int): String = {
+    val padding = n - s.length
+    if (padding <= 0) s
+    else s + "0" * padding
+  }
+  def parseInterval(in: String): RawInterval = {
+    in match {
+      case postgresIntervalRegex(years, months, days, hours, minutes, seconds, fraction) =>
+        val yearsInt = Option(years).map(_.toInt).getOrElse(0)
+        val monthsInt = Option(months).map(_.toInt).getOrElse(0)
+        val daysInt = Option(days).map(_.toInt).getOrElse(0)
+        val hoursInt = Option(hours).map(_.toInt).getOrElse(0)
+        val minutesInt = Option(minutes).map(_.toInt).getOrElse(0)
+        val secondsInt = Option(seconds).map(_.toInt).getOrElse(0)
+        // Padding the fraction to the right and taking the first 3 digits
+        // 0.1 => 100, 0.01 => 010, 0.001 => 001
+        val fractionInt = Option(fraction).map(x => padRight(x, 3).take(3).toInt).getOrElse(0)
+        val weeks = 0
+        RawInterval(yearsInt, monthsInt, weeks, daysInt, hoursInt, minutesInt, secondsInt, fractionInt)
+      case _ => throw new IllegalArgumentException(s"Invalid interval format: $in")
+    }
+  }
+
+  def intervalToString(in: RawInterval): String = {
+
+    val time = new StringBuilder()
+    val result = new StringBuilder("P")
+
+    val totalMillis = in.seconds * 1000 + in.millis
+    val s = totalMillis / 1000
+
+    val ms =
+      if (totalMillis >= 0) totalMillis % 1000
+      else -totalMillis % 1000
+
+    // P1Y2M4W5DT6H5M7.008S// P1Y2M4W5DT6H5M7.008S
+    if (in.hours != 0) time.append(in.hours + "H")
+    if (in.minutes != 0) time.append(in.minutes + "M")
+    if (s != 0 || ms != 0) time.append(f"$s%d.$ms%03dS")
+
+    if (in.years != 0) result.append(in.years + "Y")
+
+    if (in.months != 0) result.append(in.months + "M")
+
+    if (in.weeks != 0) result.append(in.weeks + "W")
+
+    if (in.days != 0) result.append(in.days + "D")
+
+    if (time.nonEmpty) result.append("T" + time.toString())
+
+    result.toString()
+  }
+}

--- a/sql-client/src/main/scala/raw/client/sql/SqlIntervals.scala
+++ b/sql-client/src/main/scala/raw/client/sql/SqlIntervals.scala
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2023 RAW Labs S.A.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0, included in the file
+ * licenses/APL.txt.
+ */
+
 package raw.client.sql
 
 import raw.client.api.RawInterval

--- a/sql-client/src/main/scala/raw/client/sql/SqlTypesUtils.scala
+++ b/sql-client/src/main/scala/raw/client/sql/SqlTypesUtils.scala
@@ -13,27 +13,9 @@
 package raw.client.sql
 
 import com.typesafe.scalalogging.StrictLogging
-import raw.client.api.{
-  RawAnyType,
-  RawBoolType,
-  RawByteType,
-  RawDateType,
-  RawDecimalType,
-  RawDoubleType,
-  RawFloatType,
-  RawIntType,
-  RawInterval,
-  RawIntervalType,
-  RawLongType,
-  RawShortType,
-  RawStringType,
-  RawTimeType,
-  RawTimestampType,
-  RawType
-}
+import raw.client.api._
 
 import scala.annotation.tailrec
-import scala.util.matching.Regex
 
 object SqlTypesUtils extends StrictLogging {
 
@@ -160,59 +142,4 @@ object SqlTypesUtils extends StrictLogging {
     recurse(options.tail, options.head)
   }
 
-  val postgresIntervalRegex: Regex =
-    """(?:(\d+)\s+years?)?(?:\s*(\d+) mons?)?(?:\s*(\d+) days?)?(?:\s*(\d+):(\d+):(\d+)(?:\.(\d+))?)?""".r
-
-  def padRight(s: String, n: Int): String = {
-    val padding = n - s.length
-    if (padding <= 0) s
-    else s + "0" * padding
-  }
-  def parseInterval(in: String): RawInterval = {
-    in match {
-      case postgresIntervalRegex(years, months, days, hours, minutes, seconds, fraction) =>
-        val yearsInt = Option(years).map(_.toInt).getOrElse(0)
-        val monthsInt = Option(months).map(_.toInt).getOrElse(0)
-        val daysInt = Option(days).map(_.toInt).getOrElse(0)
-        val hoursInt = Option(hours).map(_.toInt).getOrElse(0)
-        val minutesInt = Option(minutes).map(_.toInt).getOrElse(0)
-        val secondsInt = Option(seconds).map(_.toInt).getOrElse(0)
-        // Padding the fraction to the right and taking the first 3 digits
-        // 0.1 => 100, 0.01 => 010, 0.001 => 001
-        val fractionInt = Option(fraction).map(x => padRight(x, 3).take(3).toInt).getOrElse(0)
-        val weeks = 0
-        RawInterval(yearsInt, monthsInt, weeks, daysInt, hoursInt, minutesInt, secondsInt, fractionInt)
-      case _ => throw new IllegalArgumentException(s"Invalid interval format: $in")
-    }
-  }
-
-  def intervalToString(in: RawInterval): String = {
-
-    val time = new StringBuilder()
-    val result = new StringBuilder("P")
-
-    val totalMillis = in.seconds * 1000 + in.millis
-    val s = totalMillis / 1000
-
-    val ms =
-      if (totalMillis >= 0) totalMillis % 1000
-      else -totalMillis % 1000
-
-    // P1Y2M4W5DT6H5M7.008S// P1Y2M4W5DT6H5M7.008S
-    if (in.hours != 0) time.append(in.hours + "H")
-    if (in.minutes != 0) time.append(in.minutes + "M")
-    if (s != 0 || ms != 0) time.append(f"$s%d.$ms%03dS")
-
-    if (in.years != 0) result.append(in.years + "Y")
-
-    if (in.months != 0) result.append(in.months + "M")
-
-    if (in.weeks != 0) result.append(in.weeks + "W")
-
-    if (in.days != 0) result.append(in.days + "D")
-
-    if (time.nonEmpty) result.append("T" + time.toString())
-
-    result.toString()
-  }
 }

--- a/sql-client/src/main/scala/raw/client/sql/SqlTypesUtils.scala
+++ b/sql-client/src/main/scala/raw/client/sql/SqlTypesUtils.scala
@@ -22,6 +22,7 @@ import raw.client.api.{
   RawDoubleType,
   RawFloatType,
   RawIntType,
+  RawIntervalType,
   RawLongType,
   RawShortType,
   RawStringType,
@@ -36,6 +37,10 @@ object SqlTypesUtils extends StrictLogging {
 
   private case class SqlType(name: String, rawType: Option[RawType])
 
+  private val otherTypeMap: Map[String, RawType] = Map(
+    "interval" -> RawIntervalType(false, false),
+    "json" -> RawAnyType()
+  )
   // a mapping from JDBC types to a RawType. We also store the name of the JDBC type for error reporting.
   private val typeMap: Map[Int, SqlType] = Map(
     java.sql.Types.BIT -> SqlType("BIT", Some(RawBoolType(false, false))),
@@ -99,15 +104,22 @@ object SqlTypesUtils extends StrictLogging {
   }
 
   // returns the RawType corresponding to the given JDBC type, or an error message if the type is not supported
-  def rawTypeFromJdbc(jdbcType: Int): Either[String, RawType] = {
-    typeMap.get(jdbcType) match {
-      case Some(sqlTypeInfo) => sqlTypeInfo.rawType match {
+  def rawTypeFromJdbc(jdbcType: Int, typeName: String): Either[String, RawType] = {
+    jdbcType match {
+      // If the type is OTHER, we need to check the specific type of the column using the type name
+      case java.sql.Types.OTHER => otherTypeMap.get(typeName) match {
           case Some(t) => Right(t)
-          case None => Left(s"Unsupported SQL type: ${sqlTypeInfo.name}")
+          case None => Left(s"Unsupported SQL type: $typeName")
         }
-      case None =>
-        logger.error(s"Unsupported JDBC type: $jdbcType") // this is the internal JDBC integer type
-        Left(s"Unsupported JDBC type")
+      case _ => typeMap.get(jdbcType) match {
+          case Some(sqlTypeInfo) => sqlTypeInfo.rawType match {
+              case Some(t) => Right(t)
+              case None => Left(s"Unsupported SQL type: ${sqlTypeInfo.name}")
+            }
+          case None =>
+            logger.error(s"Unsupported JDBC type: $jdbcType") // this is the internal JDBC integer type
+            Left(s"Unsupported JDBC type")
+        }
     }
   }
 

--- a/sql-client/src/main/scala/raw/client/sql/SqlTypesUtils.scala
+++ b/sql-client/src/main/scala/raw/client/sql/SqlTypesUtils.scala
@@ -199,19 +199,19 @@ object SqlTypesUtils extends StrictLogging {
       else -totalMillis % 1000
 
     // P1Y2M4W5DT6H5M7.008S// P1Y2M4W5DT6H5M7.008S
-    if (in.hours != 0) time += (in.hours + "H")
-    if (in.minutes != 0) time += (in.minutes + "M")
-    if (s != 0 || ms != 0) time += (s + "." + ms + "%03dS")
+    if (in.hours != 0) time.append(in.hours + "H")
+    if (in.minutes != 0) time.append(in.minutes + "M")
+    if (s != 0 || ms != 0) time.append(f"$s%d.$ms%03dS")
 
-    if (in.years != 0) result += (in.years + "Y")
+    if (in.years != 0) result.append(in.years + "Y")
 
-    if (in.months != 0) result += (in.months + "M")
+    if (in.months != 0) result.append(in.months + "M")
 
-    if (in.weeks != 0) result += (in.weeks + "W")
+    if (in.weeks != 0) result.append(in.weeks + "W")
 
-    if (in.days != 0) result += (in.days + "D")
+    if (in.days != 0) result.append(in.days + "D")
 
-    if (time.nonEmpty) result += ("T" + time)
+    if (time.nonEmpty) result.append("T" + time.toString())
 
     result.toString()
   }

--- a/sql-client/src/main/scala/raw/client/sql/SqlTypesUtils.scala
+++ b/sql-client/src/main/scala/raw/client/sql/SqlTypesUtils.scala
@@ -102,8 +102,8 @@ object SqlTypesUtils extends StrictLogging {
               case None => Left(s"Unsupported SQL type: ${sqlTypeInfo.name}")
             }
           case None =>
-            logger.error(s"Unsupported JDBC type: $jdbcType") // this is the internal JDBC integer type
-            Left(s"Unsupported JDBC type")
+            logger.error(s"Unsupported SQL type: $typeName JDBC type: $jdbcType") // this is the internal JDBC integer type
+            Left(s"Unsupported SQL type $typeName")
         }
     }
   }

--- a/sql-client/src/main/scala/raw/client/sql/SqlTypesUtils.scala
+++ b/sql-client/src/main/scala/raw/client/sql/SqlTypesUtils.scala
@@ -102,7 +102,10 @@ object SqlTypesUtils extends StrictLogging {
               case None => Left(s"Unsupported SQL type: ${sqlTypeInfo.name}")
             }
           case None =>
-            logger.error(s"Unsupported SQL type: $typeName JDBC type: $jdbcType") // this is the internal JDBC integer type
+            // this is the postgres type and the internal JDBC integer type
+            logger.error(
+              s"Unsupported SQL type: $typeName JDBC type: $jdbcType"
+            )
             Left(s"Unsupported SQL type $typeName")
         }
     }

--- a/sql-client/src/main/scala/raw/client/sql/SqlTypesUtils.scala
+++ b/sql-client/src/main/scala/raw/client/sql/SqlTypesUtils.scala
@@ -39,7 +39,8 @@ object SqlTypesUtils extends StrictLogging {
 
   private val otherTypeMap: Map[String, RawType] = Map(
     "interval" -> RawIntervalType(false, false),
-    "json" -> RawAnyType()
+    "json" -> RawAnyType(),
+    "jsonb" -> RawAnyType()
   )
   // a mapping from JDBC types to a RawType. We also store the name of the JDBC type for error reporting.
   private val typeMap: Map[Int, SqlType] = Map(

--- a/sql-client/src/main/scala/raw/client/sql/SqlTypesUtils.scala
+++ b/sql-client/src/main/scala/raw/client/sql/SqlTypesUtils.scala
@@ -13,7 +13,24 @@
 package raw.client.sql
 
 import com.typesafe.scalalogging.StrictLogging
-import raw.client.api.{RawAnyType, RawBoolType, RawByteType, RawDateType, RawDecimalType, RawDoubleType, RawFloatType, RawIntType, RawInterval, RawIntervalType, RawLongType, RawShortType, RawStringType, RawTimeType, RawTimestampType, RawType}
+import raw.client.api.{
+  RawAnyType,
+  RawBoolType,
+  RawByteType,
+  RawDateType,
+  RawDecimalType,
+  RawDoubleType,
+  RawFloatType,
+  RawIntType,
+  RawInterval,
+  RawIntervalType,
+  RawLongType,
+  RawShortType,
+  RawStringType,
+  RawTimeType,
+  RawTimestampType,
+  RawType
+}
 
 import scala.annotation.tailrec
 import scala.util.matching.Regex
@@ -143,8 +160,8 @@ object SqlTypesUtils extends StrictLogging {
     recurse(options.tail, options.head)
   }
 
-
-  val postgresIntervalRegex: Regex = """(?:(\d+)\s+years?)?(?:\s*(\d+) mons?)?(?:\s*(\d+) days?)?(?:\s*(\d+):(\d+):(\d+)(?:\.(\d+))?)?""".r
+  val postgresIntervalRegex: Regex =
+    """(?:(\d+)\s+years?)?(?:\s*(\d+) mons?)?(?:\s*(\d+) days?)?(?:\s*(\d+):(\d+):(\d+)(?:\.(\d+))?)?""".r
 
   def padRight(s: String, n: Int): String = {
     val padding = n - s.length
@@ -167,5 +184,35 @@ object SqlTypesUtils extends StrictLogging {
         RawInterval(yearsInt, monthsInt, weeks, daysInt, hoursInt, minutesInt, secondsInt, fractionInt)
       case _ => throw new IllegalArgumentException(s"Invalid interval format: $in")
     }
+  }
+
+  def intervalToString(in: RawInterval): String = {
+
+    val time = new StringBuilder()
+    val result = new StringBuilder("P")
+
+    val totalMillis = in.seconds * 1000 + in.millis
+    val s = totalMillis / 1000
+
+    val ms =
+      if (totalMillis >= 0) totalMillis % 1000
+      else -totalMillis % 1000
+
+    // P1Y2M4W5DT6H5M7.008S// P1Y2M4W5DT6H5M7.008S
+    if (in.hours != 0) time += (in.hours + "H")
+    if (in.minutes != 0) time += (in.minutes + "M")
+    if (s != 0 || ms != 0) time += (s + "." + ms + "%03dS")
+
+    if (in.years != 0) result += (in.years + "Y")
+
+    if (in.months != 0) result += (in.months + "M")
+
+    if (in.weeks != 0) result += (in.weeks + "W")
+
+    if (in.days != 0) result += (in.days + "D")
+
+    if (time.nonEmpty) result += ("T" + time)
+
+    result.toString()
   }
 }

--- a/sql-client/src/main/scala/raw/client/sql/writers/TypedResultSetJsonWriter.scala
+++ b/sql-client/src/main/scala/raw/client/sql/writers/TypedResultSetJsonWriter.scala
@@ -15,6 +15,7 @@ package raw.client.sql.writers
 import com.fasterxml.jackson.core.{JsonEncoding, JsonFactory, JsonParser}
 import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
 import raw.client.api._
+import raw.client.sql.SqlTypesUtils.parseInterval
 import raw.utils.RecordFieldsNaming
 
 import java.io.{IOException, OutputStream}
@@ -108,6 +109,9 @@ class TypedResultSetJsonWriter(os: OutputStream) {
         val dateTime = v.getTimestamp(i).toLocalDateTime
         val formatted = timestampFormatter.format(dateTime)
         gen.writeString(formatted)
+      case _: RawIntervalType =>
+        val interval = parseInterval(v.getString(i))
+        gen.writeString(interval.toString)
       case _ => throw new IOException("unsupported type")
     }
   }

--- a/sql-client/src/main/scala/raw/client/sql/writers/TypedResultSetJsonWriter.scala
+++ b/sql-client/src/main/scala/raw/client/sql/writers/TypedResultSetJsonWriter.scala
@@ -15,7 +15,7 @@ package raw.client.sql.writers
 import com.fasterxml.jackson.core.{JsonEncoding, JsonFactory, JsonParser}
 import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
 import raw.client.api._
-import raw.client.sql.SqlTypesUtils.parseInterval
+import raw.client.sql.SqlTypesUtils.{intervalToString, parseInterval}
 import raw.utils.RecordFieldsNaming
 
 import java.io.{IOException, OutputStream}
@@ -111,7 +111,7 @@ class TypedResultSetJsonWriter(os: OutputStream) {
         gen.writeString(formatted)
       case _: RawIntervalType =>
         val interval = parseInterval(v.getString(i))
-        gen.writeString(interval.toString)
+        gen.writeString(intervalToString(interval))
       case _ => throw new IOException("unsupported type")
     }
   }

--- a/sql-client/src/main/scala/raw/client/sql/writers/TypedResultSetJsonWriter.scala
+++ b/sql-client/src/main/scala/raw/client/sql/writers/TypedResultSetJsonWriter.scala
@@ -15,7 +15,7 @@ package raw.client.sql.writers
 import com.fasterxml.jackson.core.{JsonEncoding, JsonFactory, JsonParser}
 import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
 import raw.client.api._
-import raw.client.sql.SqlTypesUtils.{intervalToString, parseInterval}
+import raw.client.sql.SqlIntervals.{intervalToString, parseInterval}
 import raw.utils.RecordFieldsNaming
 
 import java.io.{IOException, OutputStream}

--- a/sql-client/src/test/scala/raw/client/sql/TestParseIntervals.scala
+++ b/sql-client/src/test/scala/raw/client/sql/TestParseIntervals.scala
@@ -1,0 +1,36 @@
+package raw.client.sql
+
+import org.scalatest.funsuite.AnyFunSuite
+import raw.client.api.RawInterval
+import raw.client.sql.SqlTypesUtils.parseInterval
+class TestParseIntervals extends AnyFunSuite {
+
+  test("parse singular interval items") {
+    Map(
+      "1 year" -> RawInterval(1, 0, 0, 0, 0, 0, 0, 0),
+      "1 mon" -> RawInterval(0, 1, 0, 0, 0, 0, 0, 0),
+      "1 day" -> RawInterval(0, 0, 0, 1, 0, 0, 0, 0),
+      "01:00:00" -> RawInterval(0, 0, 0, 0, 1, 0, 0, 0),
+      "00:01:00" -> RawInterval(0, 0, 0, 0, 0, 1, 0, 0),
+      "00:00:01" -> RawInterval(0, 0, 0, 0, 0, 0, 1, 0),
+      "00:00:00.001" -> RawInterval(0, 0, 0, 0, 0, 0, 0, 1),
+      "2 years" -> RawInterval(2, 0, 0, 0, 0, 0, 0, 0),
+      "2 mons" -> RawInterval(0, 2, 0, 0, 0, 0, 0, 0),
+      "2 days" -> RawInterval(0, 0, 0, 2, 0, 0, 0, 0),
+      "02:00:00" -> RawInterval(0, 0, 0, 0, 2, 0, 0, 0),
+      "00:02:00" -> RawInterval(0, 0, 0, 0, 0, 2, 0, 0),
+      "00:00:02" -> RawInterval(0, 0, 0, 0, 0, 0, 2, 0),
+      "00:00:00.002" -> RawInterval(0, 0, 0, 0, 0, 0, 0, 2)
+    ).foreach {
+      case (k, v) =>
+        val interval = parseInterval(k)
+        assert(interval == v)
+    }
+  }
+
+  test("parse multiple items") {
+    val interval = parseInterval("1 year 2 mons 3 days 04:05:06.007")
+    assert(interval == RawInterval(1, 2, 0, 3, 4, 5, 6, 7))
+  }
+
+}

--- a/sql-client/src/test/scala/raw/client/sql/TestParseIntervals.scala
+++ b/sql-client/src/test/scala/raw/client/sql/TestParseIntervals.scala
@@ -45,4 +45,10 @@ class TestParseIntervals extends AnyFunSuite {
     assert(interval == RawInterval(1, 2, 0, 3, 4, 5, 6, 7))
   }
 
+  test("parse milliseconds") {
+    var interval = parseInterval("00:00:00.01")
+    assert(interval == RawInterval(0, 0, 0, 0, 0, 0, 0, 10))
+    interval = parseInterval("00:00:00.1234567")
+    assert(interval == RawInterval(0, 0, 0, 0, 0, 0, 0, 123))
+  }
 }

--- a/sql-client/src/test/scala/raw/client/sql/TestParseIntervals.scala
+++ b/sql-client/src/test/scala/raw/client/sql/TestParseIntervals.scala
@@ -14,7 +14,7 @@ package raw.client.sql
 
 import org.scalatest.funsuite.AnyFunSuite
 import raw.client.api.RawInterval
-import raw.client.sql.SqlTypesUtils.parseInterval
+import raw.client.sql.SqlIntervals.parseInterval
 class TestParseIntervals extends AnyFunSuite {
 
   test("parse singular interval items") {

--- a/sql-client/src/test/scala/raw/client/sql/TestParseIntervals.scala
+++ b/sql-client/src/test/scala/raw/client/sql/TestParseIntervals.scala
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2023 RAW Labs S.A.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0, included in the file
+ * licenses/APL.txt.
+ */
+
 package raw.client.sql
 
 import org.scalatest.funsuite.AnyFunSuite

--- a/sql-client/src/test/scala/raw/client/sql/TestPrintIntervals.scala
+++ b/sql-client/src/test/scala/raw/client/sql/TestPrintIntervals.scala
@@ -14,8 +14,9 @@ package raw.client.sql
 
 import org.scalatest.funsuite.AnyFunSuite
 import raw.client.api.RawInterval
-import raw.client.sql.SqlTypesUtils.intervalToString
+import raw.client.sql.SqlIntervals.intervalToString
 class TestPrintIntervals extends AnyFunSuite {
+
   test("parse singular interval items") {
     Map(
       RawInterval(1, 0, 0, 0, 0, 0, 0, 0) -> "P1Y",

--- a/sql-client/src/test/scala/raw/client/sql/TestPrintIntervals.scala
+++ b/sql-client/src/test/scala/raw/client/sql/TestPrintIntervals.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 RAW Labs S.A.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0, included in the file
+ * licenses/APL.txt.
+ */
+
+package raw.client.sql
+
+import org.scalatest.funsuite.AnyFunSuite
+import raw.client.api.RawInterval
+import raw.client.sql.SqlTypesUtils.intervalToString
+class TestPrintIntervals extends AnyFunSuite {
+  test("parse singular interval items") {
+    Map(
+      RawInterval(1, 0, 0, 0, 0, 0, 0, 0) -> "P1Y",
+      RawInterval(0, 1, 0, 0, 0, 0, 0, 0) -> "P1M",
+      RawInterval(0, 0, 1, 0, 0, 0, 0, 0) -> "P1W",
+      RawInterval(0, 0, 0, 1, 0, 0, 0, 0) -> "P1D",
+      RawInterval(0, 0, 0, 0, 1, 0, 0, 0) -> "PT1H",
+      RawInterval(0, 0, 0, 0, 0, 1, 0, 0) -> "PT1M",
+      RawInterval(0, 0, 0, 0, 0, 0, 1, 0) -> "PT1.000S",
+      RawInterval(0, 0, 0, 0, 0, 0, 0, 1) -> "PT0.001S",
+      RawInterval(2, 0, 0, 0, 0, 0, 0, 0) -> "P2Y",
+      RawInterval(0, 2, 0, 0, 0, 0, 0, 0) -> "P2M",
+      RawInterval(0, 0, 2, 0, 0, 0, 0, 0) -> "P2W",
+      RawInterval(0, 0, 0, 2, 0, 0, 0, 0) -> "P2D",
+      RawInterval(0, 0, 0, 0, 2, 0, 0, 0) -> "PT2H",
+      RawInterval(0, 0, 0, 0, 0, 2, 0, 0) -> "PT2M",
+      RawInterval(0, 0, 0, 0, 0, 0, 2, 0) -> "PT2.000S",
+      RawInterval(0, 0, 0, 0, 0, 0, 0, 2) -> "PT0.002S"
+    ).foreach { case (k, v) => assert(intervalToString(k) == v) }
+  }
+
+  test("parse multiple items") {
+    val interval = RawInterval(1, 2, 3, 4, 5, 6, 7, 8)
+    assert(intervalToString(interval) == "P1Y2M3W4DT5H6M7.008S")
+  }
+
+}


### PR DESCRIPTION
In this PR:
* Added a way of checking if jdbc.OTHER is an interval or an json
* Added a validation for input parameters.
* Added an object SqlIntervals with functions to parse pgsql intervals and convert intervals to string.
