### PR TITLE
RD-10612 hovering on a parameter name doesn't return the parameter type + fails internally

### DIFF
--- a/sql-client/src/main/scala/raw/client/sql/SqlCodeUtils.scala
+++ b/sql-client/src/main/scala/raw/client/sql/SqlCodeUtils.scala
@@ -200,7 +200,7 @@ class SqlCodeUtils(code: String) {
     val tokens = SqlCodeUtils.tokens(code)
     // Finds the corresponding token
     val maybeToken = tokens.find {
-      case (token, pos) => pos.column <= p.column && (pos.column + token.length) > p.column && pos.line == p.line
+      case (token, pos) => pos.column <= p.column && (pos.column + token.length) >= p.column && pos.line == p.line
     }
 
     maybeToken

--- a/sql-client/src/test/scala/raw/client/sql/TestSqlCompilerServiceAirports.scala
+++ b/sql-client/src/test/scala/raw/client/sql/TestSqlCompilerServiceAirports.scala
@@ -613,6 +613,19 @@ class TestSqlCompilerServiceAirports extends RawTestSuite with SettingsTestConte
       |]""".stripMargin.replaceAll("\\s+", ""))
   }
 
+  // #RD-10612: hovering on a parameter name doesn't return the parameter type + fails internally
+  // The problem is because we are at the limit of the token and we returned an empty list.
+  // However, because of the function SqlCodeUtils.identifiers right it returns an identifier with an empty string.
+  // the state machine in that function bails out because it finds the ':' at the start of the string.
+  ignore("SELECT :v > 12 AS column") { t =>
+    assume(password != "")
+
+    val environment = ProgramEnvironment(user, None, Set.empty, Map("output-format" -> "json"))
+    val hover = compilerService.hover(t.q, environment, Pos(1, 10))
+    assert(hover.completion.contains(TypeCompletion("v", "parameter")))
+
+  }
+
   private val airportColumns = Set(
     LetBindCompletion("icao", "character varying"),
     LetBindCompletion("tz", "character varying"),

--- a/sql-client/src/test/scala/raw/client/sql/TestSqlCompilerServiceAirports.scala
+++ b/sql-client/src/test/scala/raw/client/sql/TestSqlCompilerServiceAirports.scala
@@ -615,8 +615,8 @@ class TestSqlCompilerServiceAirports extends RawTestSuite with SettingsTestConte
 
   // #RD-10612: hovering on a parameter name doesn't return the parameter type + fails internally
   // The problem is because we are at the limit of the token and we returned an empty list.
-  // However, because of the function SqlCodeUtils.identifiers right it returns an identifier with an empty string.
-  // the state machine in that function bails out because it finds the ':' at the start of the string.
+  // However, because of the function SqlCodeUtils.identifiers right now it returns an identifier with an empty string.
+  // The state machine in that function bails out because it finds the ':' at the start of the string.
   ignore("SELECT :v > 12 AS column") { t =>
     assume(password != "")
 


### PR DESCRIPTION
This was because the list of tokens was empty in the `hover` method of the `SqlCompilerService`.
In the end this was because the function `getIdentifierUnder` should have used a `>=` instead of an `=` to get the boundary of the token also
