### PR TITLE
RD-10763: Replace maybeType by a Decl in ProgramDescription

### DIFF
--- a/client/src/main/scala/raw/client/api/ProgramDescription.scala
+++ b/client/src/main/scala/raw/client/api/ProgramDescription.scala
@@ -14,7 +14,7 @@ package raw.client.api
 
 final case class ProgramDescription(
     decls: Map[String, List[DeclDescription]],
-    maybeType: Option[RawType],
+    maybeRunnable: Option[DeclDescription],
     comment: Option[String]
 )
 

--- a/snapi-client/src/main/scala/raw/client/rql2/truffle/Rql2TruffleCompilerService.scala
+++ b/snapi-client/src/main/scala/raw/client/rql2/truffle/Rql2TruffleCompilerService.scala
@@ -182,7 +182,7 @@ class Rql2TruffleCompilerService(engineDefinition: (Engine, Boolean), maybeClass
               formattedDecls,
               maybeType.map { t =>
                 rql2TypeToRawType(t) match {
-                  case Some(rawType) => rawType
+                  case Some(rawType) => DeclDescription(None, rawType, None)
                   case None => return GetProgramDescriptionFailure(
                       List(ErrorMessage(UnsupportedType.message, List.empty, UnsupportedType.code))
                     )

--- a/sql-client/src/main/scala/raw/client/sql/SqlCompilerService.scala
+++ b/sql-client/src/main/scala/raw/client/sql/SqlCompilerService.scala
@@ -93,8 +93,8 @@ class SqlCompilerService(maybeClassLoader: Option[ClassLoader] = None)(implicit 
                       // Regardless if there are parameters, we declare a main function with the output type.
                       // This permits the publish endpoints from the UI (https://raw-labs.atlassian.net/browse/RD-10359)
                       val ok = ProgramDescription(
-                        Map("main" -> List(DeclDescription(Some(ps.toVector), iterableType, None))),
-                        None,
+                        Map.empty,
+                        Some(DeclDescription(Some(ps.toVector), iterableType, None)),
                         None
                       )
                       GetProgramDescriptionSuccess(ok)

--- a/sql-client/src/test/scala/raw/client/sql/TestNamedParametersStatement.scala
+++ b/sql-client/src/test/scala/raw/client/sql/TestNamedParametersStatement.scala
@@ -47,22 +47,6 @@ class TestNamedParametersStatement extends RawTestSuite with SettingsTestContext
     super.afterAll()
   }
 
-  test("bug") { _ =>
-    assume(password != "")
-
-    val code = """-- @type aeroport_id smallint
-      |SELECT :city::json FROM example.airports WHERE  airport_id = :aeroport_id""".stripMargin
-
-    val statement = new NamedParametersPreparedStatement(con, parse(code))
-    val metadata = statement.queryMetadata
-    assert(metadata.isLeft)
-    statement.setString("v1", "Hello!")
-    val rs = statement.executeQuery()
-
-    rs.next()
-    assert(rs.getString("arg") == "Hello!")
-  }
-
   test("single parameter") { _ =>
     assume(password != "")
 

--- a/sql-client/src/test/scala/raw/client/sql/TestSqlCompilerServiceAirports.scala
+++ b/sql-client/src/test/scala/raw/client/sql/TestSqlCompilerServiceAirports.scala
@@ -364,8 +364,8 @@ class TestSqlCompilerServiceAirports extends RawTestSuite with SettingsTestConte
     val v = compilerService.validate(t.q, environment)
     assert(v.messages.isEmpty)
     val GetProgramDescriptionSuccess(description) = compilerService.getProgramDescription(t.q, environment)
-    assert(description.maybeType.isEmpty)
-    val List(main) = description.decls("main")
+    assert(description.decls.isEmpty)
+    val Some(main) = description.maybeRunnable
     assert(
       main.outType == airportType
     )
@@ -409,8 +409,8 @@ class TestSqlCompilerServiceAirports extends RawTestSuite with SettingsTestConte
     val v = compilerService.validate(t.q, environment)
     assert(v.messages.isEmpty)
     val GetProgramDescriptionSuccess(description) = compilerService.getProgramDescription(t.q, environment)
-    assert(description.maybeType.isEmpty)
-    val List(main) = description.decls("main")
+    assert(description.decls.isEmpty)
+    val Some(main) = description.maybeRunnable
     assert(
       main.outType == airportType
     )
@@ -448,8 +448,8 @@ class TestSqlCompilerServiceAirports extends RawTestSuite with SettingsTestConte
     val v = compilerService.validate(t.q, environment)
     assert(v.messages.isEmpty)
     val GetProgramDescriptionSuccess(description) = compilerService.getProgramDescription(t.q, environment)
-    assert(description.maybeType.isEmpty)
-    val List(main) = description.decls("main")
+    assert(description.decls.isEmpty)
+    val Some(main) = description.maybeRunnable
     assert(
       main.outType == airportType
     )
@@ -598,8 +598,8 @@ class TestSqlCompilerServiceAirports extends RawTestSuite with SettingsTestConte
     val v = compilerService.validate(t.q, withCity)
     assert(v.messages.isEmpty)
     val GetProgramDescriptionSuccess(description) = compilerService.getProgramDescription(t.q, withCity)
-    assert(description.maybeType.isEmpty)
-    val List(main) = description.decls("main")
+    assert(description.decls.isEmpty)
+    val Some(main) = description.maybeRunnable
     assert(
       main.outType == RawIterableType(
         RawRecordType(Vector(RawAttrType("count", RawLongType(true, false))), false, false),
@@ -644,8 +644,8 @@ class TestSqlCompilerServiceAirports extends RawTestSuite with SettingsTestConte
     val v = compilerService.validate(t.q, withCity)
     assert(v.messages.isEmpty)
     val GetProgramDescriptionSuccess(description) = compilerService.getProgramDescription(t.q, withCity)
-    assert(description.maybeType.isEmpty)
-    val List(main) = description.decls("main")
+    assert(description.decls.isEmpty)
+    val Some(main) = description.maybeRunnable
     assert(
       main.outType == RawIterableType(
         RawRecordType(Vector(RawAttrType("count", RawLongType(true, false))), false, false),
@@ -674,8 +674,8 @@ class TestSqlCompilerServiceAirports extends RawTestSuite with SettingsTestConte
     val v = compilerService.validate(t.q, environment)
     assert(v.messages.isEmpty)
     val GetProgramDescriptionSuccess(description) = compilerService.getProgramDescription(t.q, environment)
-    assert(description.maybeType.isEmpty)
-    val List(main) = description.decls("main")
+    assert(description.decls.isEmpty)
+    val Some(main) = description.maybeRunnable
     assert(
       main.outType == RawIterableType(
         RawRecordType(


### PR DESCRIPTION
See the JIRA and its related subtasks for all details.

That one is only a fraction of the fix. It permits to describe an SQL program as:
* no declarations in the `decls` `Map` (it has no user declared functions),
* a defined `maybeRunnable` declaration as value. With parameters (potentially an empty list if none).

and a Snapi program as:
* its usual list of declarations, the top-level functions,
* if it has a final value, a defined `maybeRunnable` declaration: parameter-less since Snapi doesn't support to evaluate a program as a function.
* if it has no final value, an undefined `maybeRunnable`.

The rest of the patch are fixes to the SQL test codes that are testing the compiler API.