### PR TITLE
RD-10768 Documentation wrong on Snapi Date.SubtractInterval

### DIFF
--- a/snapi-frontend/src/main/scala/raw/compiler/rql2/builtin/DatePackage.scala
+++ b/snapi-frontend/src/main/scala/raw/compiler/rql2/builtin/DatePackage.scala
@@ -250,7 +250,7 @@ class DateSubtractIntervalEntry
         ret = Some(
           ReturnDoc(
             "The timestamp resulting from subtracting the interval to the date.",
-            retType = Some(TypeDoc(List("date")))
+            retType = Some(TypeDoc(List("timestamp")))
           )
         )
       )

--- a/snapi-frontend/src/main/scala/raw/compiler/rql2/builtin/DatePackage.scala
+++ b/snapi-frontend/src/main/scala/raw/compiler/rql2/builtin/DatePackage.scala
@@ -220,7 +220,10 @@ class DateAddIntervalEntry
           ParamDoc("interval", TypeDoc(List("interval")), "interval to add.")
         ),
         ret = Some(
-          ReturnDoc("The timestamp resulting from adding the interval to the date.", retType = Some(TypeDoc(List("timestamp"))))
+          ReturnDoc(
+            "The timestamp resulting from adding the interval to the date.",
+            retType = Some(TypeDoc(List("timestamp")))
+          )
         )
       )
     )

--- a/snapi-frontend/src/main/scala/raw/compiler/rql2/builtin/DatePackage.scala
+++ b/snapi-frontend/src/main/scala/raw/compiler/rql2/builtin/DatePackage.scala
@@ -220,7 +220,7 @@ class DateAddIntervalEntry
           ParamDoc("interval", TypeDoc(List("interval")), "interval to add.")
         ),
         ret = Some(
-          ReturnDoc("The date resulting from adding the interval to the date.", retType = Some(TypeDoc(List("date"))))
+          ReturnDoc("The timestamp resulting from adding the interval to the date.", retType = Some(TypeDoc(List("timestamp"))))
         )
       )
     )
@@ -249,7 +249,7 @@ class DateSubtractIntervalEntry
         ),
         ret = Some(
           ReturnDoc(
-            "The date resulting from subtracting the interval to the date.",
+            "The timestamp resulting from subtracting the interval to the date.",
             retType = Some(TypeDoc(List("date")))
           )
         )


### PR DESCRIPTION
The Date.SubtractInterval and Date.AddInterval return timestamps and not dates, so I updated the documentation.

Do we want to update the docs, like what is done here, or change the functions to return dates and not timestamps ?