### PR TITLE
Fixed RD-10801: do not parse/read Json data that has duplicated record fields

### DIFF
--- a/snapi-client/src/test/scala/raw/compiler/rql2/tests/regressions/RD10801Test.scala
+++ b/snapi-client/src/test/scala/raw/compiler/rql2/tests/regressions/RD10801Test.scala
@@ -24,6 +24,39 @@ trait RD10801Test extends CompilerTestContext {
     _ should runErrorAs("unsupported type")
   )
 
+  private val jsonContent = """[
+    |  { "f1": "", "f2": "", "f3": "", "f4": "", "f5": "", "f6": "", "f7": "" },
+    |  { "f8": "", "f9": "", "dup": "", "f10": "", "f11": "", "f12": "", "f13": "", "f14": "", "f15": "", "dup": "" }
+    |] """.stripMargin
+  private val rd10801Json = tempFile(jsonContent, "json")
+
+  test(s"""Json.InferAndParse($qqq$jsonContent$qqq)""".stripMargin)(_ should runErrorAs("unsupported type"))
+  test(
+    s"""Json.Parse($qqq$jsonContent$qqq, type record(f1: string, f2: string, dup: string, f4: string, dup: string)"""
+  )(_ should runErrorAs("unsupported type"))
+
+  test(snapi"""Json.InferAndRead("$rd10801Json")""")(_ should runErrorAs("unsupported type"))
+  test(snapi"""Json.Read("$rd10801Json", type record(f1: string, f2: string, dup: string, f4: string, dup: string)""")(
+    _ should runErrorAs("unsupported type")
+  )
+
+  private val csvContent = """f1,f2,f3,dup,f5,dup
+    |v1,v2,v3,v4,v5,v6
+    |v1,v2,v3,v4,v5,v6""".stripMargin
+  private val rd10801Csv = tempFile(csvContent, "csv")
+  test(s"""Csv.InferAndParse($qqq$csvContent$qqq)""".stripMargin)(_ should run)
+  test(
+    s"""Csv.Parse($qqq$csvContent$qqq, type collection(record(f1: string, f2: string, f3: string, dup: string, f5: string, dup: string)),
+      |     delimiter = ",")""".stripMargin
+  )(_ should run)
+
+  test(snapi"""Csv.InferAndRead($qqq$rd10801Csv$qqq)""".stripMargin)(_ should run)
+  test(
+    snapi"""Csv.Read($qqq$rd10801Csv$qqq,
+      |type collection(record(f1: string, f2: string, f3: string, dup: string, f5: string, dup: string)),
+      |delimiter = ",")""".stripMargin
+  )(_ should run)
+
   test(
     s"""Xml.Parse($qqq<?xml version="1.0"?><nothing/>$qqq, type record(nothing: collection(record(a: (int) -> float, b: int, c: int))))"""
   )(
@@ -76,16 +109,5 @@ trait RD10801Test extends CompilerTestContext {
   )(
     _ should runErrorAs("unsupported type; duplicate field: a")
   )
-
-  private val rd10801Json = """[
-    |  { "f1": "", "f2": "", "f3": "", "f4": "", "f5": "", "f6": "", "f7": "" },
-    |  { "f8": "", "f9": "", "dup": "", "f10": "", "f11": "", "f12": "", "f13": "", "f14": "", "f15": "", "dup": "" }
-    |] """.stripMargin
-
-  test(s"""Json.InferAndParse($qqq$rd10801Json$qqq)""".stripMargin)(_ should runErrorAs("unsupported type"))
-
-  private val dataset = tempFile(rd10801Json, "json")
-
-  test(snapi"""Json.InferAndRead("$dataset")""")(_ should runErrorAs("unsupported type"))
 
 }

--- a/snapi-client/src/test/scala/raw/compiler/rql2/tests/regressions/RD10801Test.scala
+++ b/snapi-client/src/test/scala/raw/compiler/rql2/tests/regressions/RD10801Test.scala
@@ -44,18 +44,30 @@ trait RD10801Test extends CompilerTestContext {
     |v1,v2,v3,v4,v5,v6
     |v1,v2,v3,v4,v5,v6""".stripMargin
   private val rd10801Csv = tempFile(csvContent, "csv")
-  test(s"""Csv.InferAndParse($qqq$csvContent$qqq)""".stripMargin)(_ should run)
+  test(s"""Csv.InferAndParse($qqq$csvContent$qqq)""".stripMargin)(_ should evaluateTo("""[
+    |  {f1: "v1", f2: "v2", f3: "v3", dup: "v4", f5: "v5", dup: "v6"},
+    |  {f1: "v1", f2: "v2", f3: "v3", dup: "v4", f5: "v5", dup: "v6"}
+    |]""".stripMargin))
   test(
     s"""Csv.Parse($qqq$csvContent$qqq, type collection(record(f1: string, f2: string, f3: string, dup: string, f5: string, dup: string)),
-      |     delimiter = ",")""".stripMargin
-  )(_ should run)
+      |     delimiter = ",", skip = 1)""".stripMargin
+  )(_ should evaluateTo("""[
+    |  {f1: "v1", f2: "v2", f3: "v3", dup: "v4", f5: "v5", dup: "v6"},
+    |  {f1: "v1", f2: "v2", f3: "v3", dup: "v4", f5: "v5", dup: "v6"}
+    |]""".stripMargin))
 
-  test(snapi"""Csv.InferAndRead($qqq$rd10801Csv$qqq)""".stripMargin)(_ should run)
+  test(snapi"""Csv.InferAndRead($qqq$rd10801Csv$qqq)""".stripMargin)(_ should evaluateTo("""[
+    |  {f1: "v1", f2: "v2", f3: "v3", dup: "v4", f5: "v5", dup: "v6"},
+    |  {f1: "v1", f2: "v2", f3: "v3", dup: "v4", f5: "v5", dup: "v6"}
+    |]""".stripMargin))
   test(
     snapi"""Csv.Read($qqq$rd10801Csv$qqq,
       |type collection(record(f1: string, f2: string, f3: string, dup: string, f5: string, dup: string)),
-      |delimiter = ",")""".stripMargin
-  )(_ should run)
+      |delimiter = ",", skip = 1)""".stripMargin
+  )(_ should evaluateTo("""[
+    |  {f1: "v1", f2: "v2", f3: "v3", dup: "v4", f5: "v5", dup: "v6"},
+    |  {f1: "v1", f2: "v2", f3: "v3", dup: "v4", f5: "v5", dup: "v6"}
+    |]""".stripMargin))
 
   test(
     s"""Xml.Parse($qqq<?xml version="1.0"?><nothing/>$qqq, type record(nothing: collection(record(a: (int) -> float, b: int, c: int))))"""

--- a/snapi-client/src/test/scala/raw/compiler/rql2/tests/regressions/RD10801Test.scala
+++ b/snapi-client/src/test/scala/raw/compiler/rql2/tests/regressions/RD10801Test.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2023 RAW Labs S.A.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0, included in the file
+ * licenses/APL.txt.
+ */
+
+package raw.compiler.rql2.tests.regressions
+
+import raw.compiler.rql2.tests.CompilerTestContext
+import raw.compiler.utils.SnapiInterpolator
+
+trait RD10801Test extends CompilerTestContext {
+
+  private val qqq = "\"\"\""
+
+  // some types are already checked, like 'function':
+  test(s"""Collection.Count(Json.Parse($qqq[]$qqq, type collection(record(a: (int) -> float, b: int, c: int))))""")(
+    _ should runErrorAs("unsupported type")
+  )
+
+  test(
+    s"""Xml.Parse($qqq<?xml version="1.0"?><nothing/>$qqq, type record(nothing: collection(record(a: (int) -> float, b: int, c: int))))"""
+  )(
+    _ should runErrorAs("unsupported type")
+  )
+
+  // duplicate args is a mistake in XML, it's not valid XML.
+  private val xmlWithDuplicateAttributes = tempFile("""<?xml version="1.0"?><nothing a="12" b="13" a="14"/>""", "xml")
+  private val xmlWithDuplicateTags = tempFile("""<?xml version="1.0"?><nothing><a>12</a><b>13</b><a>14</a></nothing>""")
+
+  test(
+    snapi"""Xml.InferAndRead("$xmlWithDuplicateAttributes")"""
+  )(
+    _ should runErrorAs("inference error") // duplicate field 'a' leads to an inferrer failure
+  )
+
+  test(
+    snapi"""Xml.InferAndRead("$xmlWithDuplicateTags")"""
+  ) { it =>
+    it should typeAs("record(b: int, a: collection(int))") // duplicate tags are inferred as a collection
+    it should run
+  }
+
+  test(
+    snapi"""Xml.Read("$xmlWithDuplicateAttributes", type record(`@a`: int, `@b`: int, `@a`: int))"""
+  )(
+    _ should runErrorAs("unsupported type; duplicate field: @a") // duplicate attribute is forbidden in XML
+  )
+
+  test(
+    snapi"""Xml.Read("$xmlWithDuplicateAttributes", type record(`@a`: int, `@b`: int))"""
+  )(
+    _ should runErrorAs("Duplicate attribute") // Jackson error at runtime
+  )
+
+  test(
+    snapi"""Xml.Read("$xmlWithDuplicateTags", type record(a: int, b: int, a: int))"""
+  )(
+    _ should runErrorAs("unsupported type; duplicate field: a") // duplicate fields are forbidden in snapi XML reading
+  )
+
+  test(
+    s"""Xml.Parse($qqq<?xml version="1.0"?><nothing a="12" b="13" a="14"></nothing>$qqq, type record(nothing: collection(record(`@a`: int, `@b`: int, `@a`: string, `#text`: string))))"""
+  )(
+    _ should runErrorAs("unsupported type; duplicate field: @a")
+  )
+
+  test(
+    s"""Xml.Parse($qqq<?xml version="1.0"?><nothing><a>12</a><b>13</b><a>14</a></nothing>$qqq, type record(nothing: collection(record(a: int, b: int, a: string))))"""
+  )(
+    _ should runErrorAs("unsupported type; duplicate field: a")
+  )
+
+  private val rd10801Json = """[
+    |  { "f1": "", "f2": "", "f3": "", "f4": "", "f5": "", "f6": "", "f7": "" },
+    |  { "f8": "", "f9": "", "dup": "", "f10": "", "f11": "", "f12": "", "f13": "", "f14": "", "f15": "", "dup": "" }
+    |] """.stripMargin
+
+  test(s"""Json.InferAndParse($qqq$rd10801Json$qqq)""".stripMargin)(_ should runErrorAs("unsupported type"))
+
+  private val dataset = tempFile(rd10801Json, "json")
+
+  test(snapi"""Json.InferAndRead("$dataset")""")(_ should runErrorAs("unsupported type"))
+
+}

--- a/snapi-client/src/test/scala/raw/compiler/rql2/tests/regressions/RD5893Test.scala
+++ b/snapi-client/src/test/scala/raw/compiler/rql2/tests/regressions/RD5893Test.scala
@@ -49,7 +49,7 @@ trait RD5893Test extends CompilerTestContext {
 
   test(
     """Xml.InferAndRead("https://rawlabs-public-test-data.s3.eu-west-1.amazonaws.com/SSO/su-d-05.04-kbob-01.xml")"""
-  )(it => it should run)
+  )(it => it should runErrorAs("duplicate field: @value-type"))
 
   val xmlType = """record(
     |    `@version`: double,
@@ -390,7 +390,7 @@ trait RD5893Test extends CompilerTestContext {
     |                                    record(
     |                                        `@style-name`: string,
     |                                        `@value-type`: string,
-    |                                        `@value-type`: string,
+    |                                        // `@value-type`: string, duplicate field isn't supported (RD-10801)
     |                                        p: collection(
     |                                            record(
     |                                                span: collection(
@@ -414,7 +414,7 @@ trait RD5893Test extends CompilerTestContext {
     |                                    `@style-name`: string,
     |                                    `@number-columns-repeated`: int,
     |                                    `@value-type`: string,
-    |                                    `@value-type`: string,
+    |                                    // `@value-type`: string, duplicate field isn't supported (RD-10801)
     |                                    p: collection(
     |                                        record(
     |                                            s: record(`@c`: int),

--- a/snapi-client/src/test/scala/raw/compiler/rql2/tests/truffle/regressions/TruffleRegressionTest.scala
+++ b/snapi-client/src/test/scala/raw/compiler/rql2/tests/truffle/regressions/TruffleRegressionTest.scala
@@ -73,3 +73,4 @@ import raw.testing.tags.TruffleTests
 @TruffleTests class RD10194TruffleTest extends TruffleCompilerTestContext with RD10194Test
 @TruffleTests class RD10220TruffleTest extends TruffleCompilerTestContext with RD10220Test
 @TruffleTests class RD10723TruffleTest extends TruffleCompilerTestContext with RD10723Test
+@TruffleTests class RD10801TruffleTest extends TruffleCompilerTestContext with RD10801Test

--- a/snapi-frontend/src/main/scala/raw/compiler/base/errors/Errors.scala
+++ b/snapi-frontend/src/main/scala/raw/compiler/base/errors/Errors.scala
@@ -127,7 +127,13 @@ object MultipleDecl {
  * @param t The type that is unsupported.
  * @param parent The top-level type. (e.g. if collection(int). Set to None if t == parent.
  */
-final case class UnsupportedType(node: BaseNode, t: Type, parent: Option[Type]) extends ErrorCompilerMessage {
+final case class UnsupportedType(
+    node: BaseNode,
+    t: Type,
+    parent: Option[Type],
+    hint: Option[String] = None,
+    suggestions: Seq[String] = Seq.empty
+) extends ErrorCompilerMessage {
   val code: String = UnsupportedType.code
 }
 object UnsupportedType {

--- a/snapi-frontend/src/main/scala/raw/compiler/base/errors/ErrorsPrettyPrinter.scala
+++ b/snapi-frontend/src/main/scala/raw/compiler/base/errors/ErrorsPrettyPrinter.scala
@@ -27,8 +27,9 @@ trait ErrorsPrettyPrinter extends base.source.SourcePrettyPrinter {
     case UnknownDecl(i, hints, suggestions) =>
       handleHintsAndSuggestions(text(i.idn) <+> "is not declared", hints, suggestions)
     case MultipleDecl(i) => text(i.idn) <+> "is declared more than once"
-    case UnsupportedType(_, NotValueType(), _) => "non-executable query"
-    case UnsupportedType(_, _, _) => "unsupported type"
+    case UnsupportedType(_, NotValueType(), _, _, _) => "non-executable query"
+    case UnsupportedType(_, _, _, hints, suggestions) =>
+      handleHintsAndSuggestions("unsupported type", hints, suggestions)
     case ExternalError(_, lang, errors) => lang <+> "error: " <+> ssep(errors.map(executorErrorToDoc).to, ",")
     // Warnings
     case MissingSecretWarning(_, reason) => reason


### PR DESCRIPTION
Here's a fix to the fact our Json parser/reader can't load data that has duplicated fields (since it reads fields out of order, it wouldn't know which one to pick). Records with duplicated fields are considered as not supported, like functions, package, etc.

There was some refactoring of the `validateJsonType` function so that it can apply to both user entered types (which we can underline in the error) or the inferred entered type.

With that patch, `UnsupportedType` supports _hint_ which permits to flag the duplicate field in the error message returned to the user.

I also edited XML which cannot parse records with duplicate fields (duplicate tags lead to a collection).

As part of the fix, I noticed `Json.Print` was failing if its parameter wouldn't be supported by our reader. Which turns out to be slightly wrong: it should fail if its parameter isn't supported by our _writer_. Because it never _parses_ a string, it only _renders_ data as string. In particular, it deals with duplicate fields like our regular query writer does (they're renamed). I changed that too.