### PR TITLE
fix(parsers): release build should make sure snapi-frontend includes a release version

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -31,7 +31,7 @@ jobs:
         ref: ${{ github.event.client_payload.pull_request.head.sha }}
         fetch-depth: 0
     - name: build all
-      run: ./rebuild.sh
+      run: ./rebuild.sh --release
     - name: sbt ci-release utils
       run: ./release.sh
       working-directory: utils

--- a/parsers/build.sh
+++ b/parsers/build.sh
@@ -9,5 +9,15 @@ sdk use java 21-graalce
 cd "$SCRIPT_HOME"
 
 VERSION=$(git describe --tags | sed 's/^v//;s/-\([0-9]*\)-g/+\1-/')
-mvn clean install -Drevision=$VERSION
-echo "${VERSION}-SNAPSHOT" > version
+MVN_OPTS="-Drevision=$VERSION"
+VERSION_SUFFIX="-SNAPSHOT"
+for arg in "$@"
+do
+  if [[ $arg == "--release" ]]; then
+    MVN_OPTS="$MVN_OPTS -Dchangelist="
+    VERSION_SUFFIX=""
+    break
+  fi
+done
+mvn clean install $MVN_OPTS
+echo "${VERSION}${VERSION_SUFFIX}" > version

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -exu
+#!/bin/bash -ex
 SCRIPT_HOME="$(cd "$(dirname "$0")"; pwd)"
 
 export COURSIER_PROGRESS=false
@@ -15,7 +15,13 @@ cd "${SCRIPT_HOME}/client"
 ./build.sh
 
 cd "${SCRIPT_HOME}/parsers"
-./build.sh
+if [ "$1" == "--release" ]; then
+    cd "${SCRIPT_HOME}/parsers"
+    ./build.sh --release
+else
+    cd "${SCRIPT_HOME}/parsers"
+    ./build.sh
+fi
 
 cd "${SCRIPT_HOME}/snapi-frontend"
 ./build.sh


### PR DESCRIPTION
With the current setup, the published `pom.xml` of `snapi-frontend` is relying on a `-SNAPSHOT` version.
This PR is fixing that