### PR TITLE
fix(publish): explicit skip for publishSigned and publishLocal

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,7 @@ import com.jsuereth.sbtpgp.PgpKeys.{publishSigned}
 
 publish / skip := true
 publishSigned / skip  := true
+publishLocal / skip := true
 
 ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org"
 ThisBuild / sonatypeRepository := "https://s01.oss.sonatype.org/service/local"

--- a/build.sbt
+++ b/build.sbt
@@ -30,6 +30,7 @@ writeVersionToFile := {
   streams.value.log.info(s"Project version $versionString written to ${file.getPath}")
 }
 
+//fake commit
 lazy val root = (project in file("."))
   .aggregate(
     utils,

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,6 @@ writeVersionToFile := {
   streams.value.log.info(s"Project version $versionString written to ${file.getPath}")
 }
 
-//fake commit
 lazy val root = (project in file("."))
   .aggregate(
     utils,

--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,7 @@ import scala.sys.process._
 import com.jsuereth.sbtpgp.PgpKeys.{publishSigned}
 
 publish / skip := true
+publishSigned / skip  := true
 
 ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org"
 ThisBuild / sonatypeRepository := "https://s01.oss.sonatype.org/service/local"

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -5,6 +5,7 @@ import sbt._
 
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport._
 import java.time.Year
+import com.jsuereth.sbtpgp.PgpKeys.{publishSigned}
 
 object BuildSettings {
   lazy val licenseHeader = """Copyright 2024 RAW Labs S.A.
@@ -37,7 +38,8 @@ object BuildSettings {
     resolvers ++= Resolver.sonatypeOssRepos("snapshots"),
     resolvers ++= Resolver.sonatypeOssRepos("releases"),
     updateOptions := updateOptions.in(Global).value.withCachedResolution(true),
-    publish / skip := false
+    publish / skip := false,
+    publishSigned / skip  := false
   )
 
   lazy val commonCompileSettings = Seq(

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -39,7 +39,8 @@ object BuildSettings {
     resolvers ++= Resolver.sonatypeOssRepos("releases"),
     updateOptions := updateOptions.in(Global).value.withCachedResolution(true),
     publish / skip := false,
-    publishSigned / skip  := false
+    publishSigned / skip  := false,
+    publishLocal / skip := false
   )
 
   lazy val commonCompileSettings = Seq(


### PR DESCRIPTION
SInce release of SNAPSHOT version is using `publish` task, everything was ok regarding what is defined in `root` but non-SNAPSHOT version (for example: release tag version)  is using `publishSigned` we also need to exlude it for `root` project
We do the same with `publishLocal` 