### PR TITLE
Fixed RD-10865: Http.Get crashing if passed null key/value in args or headers

### DIFF
--- a/snapi-frontend/src/main/scala/raw/compiler/rql2/builtin/HttpPackage.scala
+++ b/snapi-frontend/src/main/scala/raw/compiler/rql2/builtin/HttpPackage.scala
@@ -179,13 +179,13 @@ abstract class HttpCallEntry(method: String) extends EntryExtension {
       ParamDoc(
         "args",
         TypeDoc(List("list")),
-        "The query parameters arguments for the HTTP request. Parameters are URL-encoded automatically.",
+        "The query parameters arguments for the HTTP request. Parameters are URL-encoded automatically. Any key/value pair with a null key or value will be omitted and won't be included in the URL parameters.",
         isOptional = true
       ),
       ParamDoc(
         "headers",
         TypeDoc(List("list")),
-        "The HTTP headers to include in the request.",
+        "The HTTP headers to include in the request. Any key/value pair with a null key or value will be omitted and won't be included in the request headers.",
         isOptional = true
       ),
       ParamDoc("expectedStatus", TypeDoc(List("list")), "The list of expected statuses.", isOptional = true)

--- a/snapi-truffle/src/main/java/raw/runtime/truffle/ast/expressions/builtin/location_package/LocationBuildNode.java
+++ b/snapi-truffle/src/main/java/raw/runtime/truffle/ast/expressions/builtin/location_package/LocationBuildNode.java
@@ -120,7 +120,9 @@ public class LocationBuildNode extends ExpressionNode {
           Object keys = interops.getMembers(record);
           Object key = interops.readMember(record, (String) interops.readArrayElement(keys, 0));
           Object val = interops.readMember(record, (String) interops.readArrayElement(keys, 1));
-          vec = vec.$plus$eq(Tuple2.apply((String) key, (String) val));
+          // ignore entries where key or val is null
+          if (key != NullObject.INSTANCE && val != NullObject.INSTANCE)
+            vec = vec.$plus$eq(Tuple2.apply((String) key, (String) val));
         }
         return new LocationKVSetting(vec.result());
       } else if (TypeGuards.isBinaryKind(type)) {


### PR DESCRIPTION
With that changeset, they're filtered out.