### PR TITLE
Fixed RD-10867: SQL compiler crashes if given snapi code

### DIFF
--- a/sql-client/src/main/scala/raw/client/sql/antlr4/RawSqlVisitor.scala
+++ b/sql-client/src/main/scala/raw/client/sql/antlr4/RawSqlVisitor.scala
@@ -72,6 +72,10 @@ class RawSqlVisitor(
     Option(ctx).flatMap(context => Option(context.code()).map(codeCtx => visit(codeCtx))).getOrElse(SqlErrorNode())
   }
 
+  override protected def defaultResult(): SqlErrorNode = {
+    SqlErrorNode();
+  }
+
   override def visitCode(ctx: PsqlParser.CodeContext): SqlBaseNode = Option(ctx)
     .map { context =>
       val statement = Option(context.stmt())

--- a/sql-client/src/test/scala/raw/client/sql/TestSqlCompilerServiceAirports.scala
+++ b/sql-client/src/test/scala/raw/client/sql/TestSqlCompilerServiceAirports.scala
@@ -942,4 +942,12 @@ class TestSqlCompilerServiceAirports
     val hover2 = compilerService.hover(t.q, asJson(), Pos(1, 20))
     assert(hover2.completion.contains(TypeCompletion("city", "character varying")))
   }
+
+  // RD-10865 (mistakenly passing snapi code)
+  test("""[{a: 12}, null]""".stripMargin) { t =>
+    assume(password != "")
+    val v = compilerService.validate(t.q, asJson())
+    assert(v.messages.exists(_.message contains "the input does not form a valid statement or expression"))
+  }
+
 }


### PR DESCRIPTION
Without the patch, and given the "totally unparsable" code tested, ANTLR returns the default result. Which by default is a `null` ref. We crash on that reference when setting positions.