### PR TITLE
fix(sbt): .sbtops missing at root level

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,7 @@ name: CI
 on:
   pull_request:
     paths:
+      - .sbtopts
       - build.sbt
       - project/**
       - deps/**

--- a/.sbtops
+++ b/.sbtops
@@ -1,0 +1,5 @@
+-J-Xmx4G
+-J-XX:+UseG1GC
+-J--add-opens=java.base/java.lang=ALL-UNNAMED
+-J--add-opens=java.base/java.util=ALL-UNNAMED
+-J-XX:+CrashOnOutOfMemoryError

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,3 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
-java=21.0.1-amzn
+java=21.0.1-graalce


### PR DESCRIPTION
`.sbtopts` got lost when migrating from multi-sbt build def to single sbt build def