### PR TITLE
refactor(build): CopyrightHeader AutoPlugin

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,8 +84,8 @@ jobs:
           yes n | sdk install java 21.0.1-graalce || true
           sdk use java 21.0.1-graalce
           echo "$SDKMAN_DIR/candidates/java/current/bin" >> $GITHUB_PATH
-      ##- name: headers
-      ##  run: sbt headerCheckAll
+      - name: headers
+        run: sbt headerCheckAll
       - name: scala fmt
         run: sbt scalafmtCheckAll
       - name: java fmt

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -8,22 +8,12 @@ import java.time.Year
 import com.jsuereth.sbtpgp.PgpKeys.{publishSigned}
 
 object BuildSettings {
-  lazy val licenseHeader = """Copyright 2024 RAW Labs S.A.
-
-  Use of this software is governed by the Business Source License
-  included in the file licenses/BSL.txt.
-
-  As of the Change Date specified in that file, in accordance with
-  the Business Source License, use of this software will be governed
-  by the Apache License, Version 2.0, included in the file
-  licenses/APL.txt."""
-
   lazy val commonSettings = Seq(
     name := "raw-" + baseDirectory.value.getName,
-    headerLicense := Some(HeaderLicense.Custom(licenseHeader)),
     homepage := Some(url("https://www.raw-labs.com/")),
     organization := "com.raw-labs",
     organizationName := "RAW Labs SA",
+    startYear := Some(2023),
     organizationHomepage := Some(url("https://www.raw-labs.com/")),
     developers := List(Developer("raw-labs", "RAW Labs", "engineering@raw-labs.com", url("https://github.com/raw-labs"))),
     licenses := List(
@@ -31,8 +21,6 @@ object BuildSettings {
         "https://raw.githubusercontent.com/raw-labs/snapi/main/licenses/BSL.txt"
       ).toURL
     ),
-    startYear := Some(2023),
-    headerLicense := Some(HeaderLicense.Custom(licenseHeader)),
     headerSources / excludeFilter := HiddenFileFilter,
     resolvers += Resolver.mavenLocal,
     resolvers ++= Resolver.sonatypeOssRepos("snapshots"),

--- a/project/CopyrightHeader.scala
+++ b/project/CopyrightHeader.scala
@@ -1,0 +1,70 @@
+package raw.build
+
+import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport._
+import de.heikoseeberger.sbtheader.{ CommentCreator, HeaderPlugin }
+import sbt.Keys._
+import sbt.{ Def, _ }
+
+import java.time.LocalDate
+
+
+object CopyrightHeader extends AutoPlugin {
+
+  override def requires: Plugins = HeaderPlugin
+
+  override def trigger: PluginTrigger = allRequirements
+
+  protected def headerMappingSettings: Seq[Def.Setting[_]] =
+    Seq(Compile, Test).flatMap { config =>
+      inConfig(config)(
+        Seq(
+          headerLicense := Some(HeaderLicense.Custom(header)),
+          headerMappings := headerMappings.value ++ Map(
+              HeaderFileType.scala -> cStyleComment,
+              HeaderFileType.java -> cStyleComment
+          )
+        )
+      )
+    }
+
+  override def projectSettings: Seq[Def.Setting[_]] = Def.settings(headerMappingSettings, additional)
+
+  def additional: Seq[Def.Setting[_]] =
+    Def.settings(Compile / compile := {
+      (Compile / headerCreate).value
+      (Compile / compile).value
+    }, Test / compile := {
+      (Test / headerCreate).value
+      (Test / compile).value
+    })
+
+  def header: String = {
+    val currentYear = "2024"
+    s"""|/*
+        | * Copyright $currentYear RAW Labs S.A.
+        | *
+        | * Use of this software is governed by the Business Source License
+        | * included in the file licenses/BSL.txt.
+        | *
+        | * As of the Change Date specified in that file, in accordance with
+        | * the Business Source License, use of this software will be governed
+        | * by the Apache License, Version 2.0, included in the file
+        | * licenses/APL.txt.
+        | */""".stripMargin
+  }
+
+  val cStyleComment = HeaderCommentStyle.cStyleBlockComment.copy(commentCreator = new CommentCreator() {
+    val CopyrightPattern = "Copyright (\\d{4}) RAW Labs S.A.".r
+
+    override def apply(text: String, existingText: Option[String]): String = {
+      existingText match {
+        case Some(existingHeader) if CopyrightPattern.findFirstIn(existingHeader).isDefined =>
+          // matches the pattern with any year, return it unchanged
+          existingHeader.trim
+        case _ =>
+          header
+      }
+    }
+  })
+
+}


### PR DESCRIPTION
We move the way we manage our header license to an auto plugin.
We still make use of the `sbt-header` plugin but we override some methods and settings in order to have the following behavior

- if a file already contains a copyright header we are not touching it and sbt headerCheck will pass
- if no header is found we add a copyright header at compilation with current year 

This PR is only about this auto plugin, after we merge this another PR will come to align all copyright headers and years

We take advantage of this PR to re-activate `sbt headerCheckAll` in CI