### PR TITLE
RD-10895: Salesforce credential expired leads to an unexpected error 500

### DIFF
--- a/client/src/main/scala/raw/client/api/CompilerService.scala
+++ b/client/src/main/scala/raw/client/api/CompilerService.scala
@@ -30,8 +30,9 @@ final class CompilerServiceException(
 
   def this(t: Throwable, debugInfo: List[(String, String)]) = this(t.getMessage, debugInfo, t)
 
-  def this(t: Throwable, environment: ProgramEnvironment) =
-    this(t.getMessage, CompilerService.getDebugInfo(environment))
+  def this(t: Throwable, environment: ProgramEnvironment) = {
+    this(t, CompilerService.getDebugInfo(environment))
+  }
 
   def this(t: Throwable) = this(t.getMessage, cause = t)
 

--- a/sql-client/src/main/scala/raw/client/sql/NamedParametersPreparedStatement.scala
+++ b/sql-client/src/main/scala/raw/client/sql/NamedParametersPreparedStatement.scala
@@ -395,7 +395,18 @@ class NamedParametersPreparedStatement(conn: Connection, parsedTree: ParseProgra
         mandatoryParameters.remove(p)
     }
     if (mandatoryParameters.nonEmpty) Left(s"no value was specified for ${mandatoryParameters.mkString(", ")}")
-    else Right(stmt.executeQuery())
+    else
+      try {
+        Right(stmt.executeQuery())
+      } catch {
+        // We'd catch here user-visible PSQL runtime errors (e.g. schema not found, table not found,
+        // wrong credentials) hit _at runtime_ because the user FDW schema.table maps to a datasource
+        // that has ... changed (e.g. the database doesn't have the table anymore, a remote service
+        // account has expired (RD-10895)). We report these errors to the user.
+        case ex: PSQLException =>
+          val error = ex.getMessage // it has the code, the message, hint, etc.
+          Left(error)
+      }
   }
 
   def close(): Unit = stmt.close()


### PR DESCRIPTION
It would be nice to test the change using an expired credential. What I believe happens is: the "connection error" that occurs due to the expired credential, occurs _at runtime_ for us, when running the SQL query. In the actual code logic, any `PSQLException` is assumed to be an internal failure, since the user query has been validated successfully. However a runtime error can be due to connection failures to the datasource (the case in the ticket), or "second level validation errors":
* the original source table is gone or was renamed: if so, our Postgres engine validates a user query reading a table that eventually doesn't exist,
* the table exists, but isn't readable,
* the password was changed, etc.

In this changeset, all PSQL errors (which include errors due to the remote source failing), are reported to the user.