### PR TITLE
fix(ci): run the right jvm when runner image contains multiple

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,7 +92,13 @@ jobs:
       - name: java fmt
         run: sbt javafmtCheckAll
       - name: doc
-        run: sbt doc
+        run: |
+          export HOME="/home/sbtuser"
+          export SDKMAN_DIR="$HOME/.sdkman"
+          source $SDKMAN_DIR/bin/sdkman-init.sh
+          yes n | sdk install java 21.0.1-graalce || true
+          sdk use java 21.0.1-graalce
+          sbt doc
   tests:
     needs: build-custom-deps
     strategy:
@@ -125,8 +131,10 @@ jobs:
         with:
           name: m2
           path: /home/sbtuser/.m2/repository
-      - name: sdkman java setup
-        id: sdkman
+      - uses: oNaiPs/secrets-to-env-action@v1.5
+        with:
+          secrets: ${{ toJSON(secrets) }}
+      - name: test
         run: |
           export HOME="/home/sbtuser"
           export SDKMAN_DIR="$HOME/.sdkman"
@@ -134,11 +142,7 @@ jobs:
           yes n | sdk install java 21.0.1-graalce || true
           sdk use java 21.0.1-graalce
           echo "$SDKMAN_DIR/candidates/java/current/bin" >> $GITHUB_PATH
-      - uses: oNaiPs/secrets-to-env-action@v1.5
-        with:
-          secrets: ${{ toJSON(secrets) }}
-      - name: test
-        run: sbt ${{ matrix.component }}/test
+          sbt ${{ matrix.component }}/test
       - uses: mikepenz/action-junit-report@v4
         if: success() || failure()
         with:


### PR DESCRIPTION
because of recent change on raw-scala-runner image, we have multiple graalvm versions, here we make sure to use the right one in each shell before running sbt tasks