### PR TITLE
Fixed RD-10924: SQL @default parser in multiline does not accept more than one word

### DIFF
--- a/sql-client/src/main/scala/raw/client/sql/antlr4/RawSqlVisitor.scala
+++ b/sql-client/src/main/scala/raw/client/sql/antlr4/RawSqlVisitor.scala
@@ -441,12 +441,12 @@ class RawSqlVisitor(
       if (context.multiline_word_or_star(0) == null) {
         addError("Missing name for syntax @default <name> <value>", context)
         SqlErrorNode()
-      } else if (context.multiline_word_or_star(1) == null) {
+      } else if (context.multiline_word_or_star.size() <= 1) {
         addError("Missing default value for syntax @default <name> <value>", context)
         SqlErrorNode()
       } else {
         val name = context.multiline_word_or_star(0).getText
-        val defaultValue = context.multiline_word_or_star(1).getText
+        val defaultValue = context.multiline_word_or_star.asScala.tail.map(_.getText.trim).mkString(" ")
         val paramDefaultComment = SqlParamDefaultCommentNode(name, defaultValue)
         positionsWrapper.setPosition(ctx, paramDefaultComment)
 

--- a/sql-parser/src/main/java/raw/psql/grammar/PsqlParser.g4
+++ b/sql-parser/src/main/java/raw/psql/grammar/PsqlParser.g4
@@ -60,7 +60,7 @@ multiline_param_comment: ML_PARAM_KW (multiline_word_or_star)+
 multiline_type_comment: ML_TYPE_KW (multiline_word_or_star)+
                       ;
 
-multiline_default_comment: ML_DEFAULT_KW multiline_word_or_star multiline_word_or_star
+multiline_default_comment: ML_DEFAULT_KW (multiline_word_or_star)+
                          ;
 
 multiline_return_comment: ML_RETURN_KW (multiline_word_or_star)+


### PR DESCRIPTION
Added a test and verified it fails without the patch.