### PR TITLE
RD-10863 Improve Snapi docs on Http regarding 'args'

### DIFF
--- a/snapi-frontend/src/main/scala/raw/compiler/rql2/builtin/HttpPackage.scala
+++ b/snapi-frontend/src/main/scala/raw/compiler/rql2/builtin/HttpPackage.scala
@@ -103,7 +103,8 @@ abstract class HttpCallEntry(method: String) extends EntryExtension {
       ExampleDoc(
         s"""Http.${method.capitalize}(
           |  "https://www.somewhere.com/something",
-          |  headers = [{ "Content-Type", "application/json"}],
+          |  headers = [{"Content-Type", "application/json"}],
+          |  args = [{"download", "true"}],
           |  bodyString = Json.Print({name: "john", age: 35})
           |)""".stripMargin
       )
@@ -179,13 +180,17 @@ abstract class HttpCallEntry(method: String) extends EntryExtension {
       ParamDoc(
         "args",
         TypeDoc(List("list")),
-        "The query parameters arguments for the HTTP request. Parameters are URL-encoded automatically. Any key/value pair with a null key or value will be omitted and won't be included in the URL parameters.",
+        """The query parameters arguments for the HTTP request.
+          |<br/>Parameters are a list of tuples (string, string) e.g. `[{"name", "john"}, {"age", "22"}]`. They are URL-encoded automatically.
+          |Any key/value pair with a null key or value will be omitted and won't be included in the URL parameters.""".stripMargin,
         isOptional = true
       ),
       ParamDoc(
         "headers",
         TypeDoc(List("list")),
-        "The HTTP headers to include in the request. Any key/value pair with a null key or value will be omitted and won't be included in the request headers.",
+        """The HTTP headers to include in the request.
+          |<br/>Headers are a list of tuples (string, string) e.g. `[{"Authorization", "Bearer 1234"}, {"Accept", "application/json"}]`.
+          |Any key/value pair with a null key or value will be omitted and won't be included in the request headers.""".stripMargin,
         isOptional = true
       ),
       ParamDoc("expectedStatus", TypeDoc(List("list")), "The list of expected statuses.", isOptional = true)

--- a/snapi-frontend/src/main/scala/raw/compiler/rql2/builtin/HttpPackage.scala
+++ b/snapi-frontend/src/main/scala/raw/compiler/rql2/builtin/HttpPackage.scala
@@ -192,7 +192,9 @@ abstract class HttpCallEntry(method: String) extends EntryExtension {
       ParamDoc("expectedStatus", TypeDoc(List("list")), "The list of expected statuses.", isOptional = true)
     ),
     ret = Some(ReturnDoc("A location to read from.", retType = Some(TypeDoc(List("location"))))),
-    info = Some("""Any key/value pair with a null key or value in the `headers` or in the `args` parameters will be omitted and won't be included in the request.""")
+    info = Some(
+      """Any key/value pair with a null key or value in the `headers` or in the `args` parameters will be omitted and won't be included in the request."""
+    )
   )
 
   override def nrMandatoryParams: Int = 1

--- a/snapi-frontend/src/main/scala/raw/compiler/rql2/builtin/HttpPackage.scala
+++ b/snapi-frontend/src/main/scala/raw/compiler/rql2/builtin/HttpPackage.scala
@@ -180,22 +180,19 @@ abstract class HttpCallEntry(method: String) extends EntryExtension {
       ParamDoc(
         "args",
         TypeDoc(List("list")),
-        """The query parameters arguments for the HTTP request.
-          |<br/>Parameters are a list of tuples (string, string) e.g. `[{"name", "john"}, {"age", "22"}]`. They are URL-encoded automatically.
-          |Any key/value pair with a null key or value will be omitted and won't be included in the URL parameters.""".stripMargin,
+        """The query parameters arguments for the HTTP request, e.g. `[{"name", "john"}, {"age", "22"}]`. They are URL-encoded automatically.""".stripMargin,
         isOptional = true
       ),
       ParamDoc(
         "headers",
         TypeDoc(List("list")),
-        """The HTTP headers to include in the request.
-          |<br/>Headers are a list of tuples (string, string) e.g. `[{"Authorization", "Bearer 1234"}, {"Accept", "application/json"}]`.
-          |Any key/value pair with a null key or value will be omitted and won't be included in the request headers.""".stripMargin,
+        """The HTTP headers to include in the request, e.g. `[{"Authorization", "Bearer 1234"}, {"Accept", "application/json"}]`.""".stripMargin,
         isOptional = true
       ),
       ParamDoc("expectedStatus", TypeDoc(List("list")), "The list of expected statuses.", isOptional = true)
     ),
-    ret = Some(ReturnDoc("A location to read from.", retType = Some(TypeDoc(List("location")))))
+    ret = Some(ReturnDoc("A location to read from.", retType = Some(TypeDoc(List("location"))))),
+    info = Some("""Any key/value pair with a null key or value in the `headers` or in the `args` parameters will be omitted and won't be included in the request.""")
   )
 
   override def nrMandatoryParams: Int = 1


### PR DESCRIPTION
Added the type for args and headers and added an example.
This is how the new docs look like:

![image](https://github.com/raw-labs/snapi/assets/7079186/f86a1d77-e85f-4927-96b5-79013352897f)
