### PR TITLE
[Experimental] Add `executeAsRawValue` to the CompilerService

### DIFF
--- a/client/src/main/scala/raw/client/api/CompilerService.scala
+++ b/client/src/main/scala/raw/client/api/CompilerService.scala
@@ -112,6 +112,14 @@ trait CompilerService extends RawService {
       environment: ProgramEnvironment
   ): EvalResponse
 
+  // Evaluate a source program and return the result as a RawValue.
+  @throws[CompilerServiceException]
+  def executeAsRawValue(
+      source: String,
+      environment: ProgramEnvironment,
+      maybeDecl: Option[String]
+  ): EvalResponse
+
   // Execute a source program and write the results to the output stream.
   @throws[CompilerServiceException]
   def execute(

--- a/sql-client/src/main/scala/raw/client/sql/SqlCompilerService.scala
+++ b/sql-client/src/main/scala/raw/client/sql/SqlCompilerService.scala
@@ -138,6 +138,18 @@ class SqlCompilerService(maybeClassLoader: Option[ClassLoader] = None)(implicit 
     }
   }
 
+  override def executeAsRawValue(
+      source: String,
+      environment: ProgramEnvironment,
+      maybeDecl: Option[String]
+  ): EvalResponse = {
+    try {
+      ???
+    } catch {
+      case NonFatal(t) => throw new CompilerServiceException(t, environment)
+    }
+  }
+
   override def eval(source: String, tipe: RawType, environment: ProgramEnvironment): EvalResponse = {
     try {
       ???


### PR DESCRIPTION
This API is like the existing `execute`, but it returns `RawValue` instead of writing to an `OutputStream`.