### PR TITLE
Make key scopes visible to SQL

### DIFF
--- a/snapi-frontend/src/main/scala/raw/creds/local/LocalCredentialsService.scala
+++ b/snapi-frontend/src/main/scala/raw/creds/local/LocalCredentialsService.scala
@@ -146,7 +146,7 @@ class LocalCredentialsService extends CredentialsService {
   }
 
   override def getUserDb(user: AuthenticatedUser): String = {
-    "unittest"
+    "default-user-db"
   }
 
   override def doStop(): Unit = {}

--- a/snapi-frontend/src/main/scala/raw/creds/local/LocalCredentialsService.scala
+++ b/snapi-frontend/src/main/scala/raw/creds/local/LocalCredentialsService.scala
@@ -146,7 +146,7 @@ class LocalCredentialsService extends CredentialsService {
   }
 
   override def getUserDb(user: AuthenticatedUser): String = {
-    "default-user-db"
+    "unittest"
   }
 
   override def doStop(): Unit = {}

--- a/sql-client/src/main/scala/raw/client/sql/SqlCompilerService.scala
+++ b/sql-client/src/main/scala/raw/client/sql/SqlCompilerService.scala
@@ -61,10 +61,10 @@ class SqlCompilerService(maybeClassLoader: Option[ClassLoader] = None)(implicit 
     syntaxAnalyzer.parse(prog)
   }
 
-  private def treeErrors(tree: ParseProgramResult, messages: Seq[String]): Seq[ErrorMessage] = {
-    val start = tree.positions.getStart(tree).get
+  private def treeErrors(program: ParseProgramResult, messages: Seq[String]): Seq[ErrorMessage] = {
+    val start = program.positions.getStart(program.tree).get
     val startPosition = ErrorPosition(start.line, start.column)
-    val end = tree.positions.getFinish(tree).get
+    val end = program.positions.getFinish(program.tree).get
     val endPosition = ErrorPosition(end.line, end.column)
     messages.map(message => ErrorMessage(message, List(ErrorRange(startPosition, endPosition)), ErrorCode.SqlErrorCode))
   }
@@ -159,7 +159,7 @@ class SqlCompilerService(maybeClassLoader: Option[ClassLoader] = None)(implicit 
         case Right(parsedTree) =>
           val conn = connectionPool.getConnection(environment.user)
           try {
-            val pstmt = new NamedParametersPreparedStatement(conn, parsedTree)
+            val pstmt = new NamedParametersPreparedStatement(conn, parsedTree, environment.scopes)
             try {
               pstmt.queryMetadata match {
                 case Right(info) => pgRowTypeToIterableType(info.outputType) match {

--- a/sql-client/src/test/scala/raw/client/sql/TestNamedParametersStatement.scala
+++ b/sql-client/src/test/scala/raw/client/sql/TestNamedParametersStatement.scala
@@ -26,11 +26,11 @@ class TestNamedParametersStatement
     with CredentialsTestContext
     with LocalCredentialsTestContext {
 
-  private val database = sys.env.getOrElse("FDW_DATABASE", "unittest")
+  private val database = sys.env.getOrElse("FDW_DATABASE", "raw")
   private val hostname = sys.env.getOrElse("FDW_HOSTNAME", "localhost")
   private val port = sys.env.getOrElse("FDW_HOSTNAME", "5432")
-  private val username = sys.env.getOrElse("FDW_USERNAME", "postgres")
-  private val password = sys.env.getOrElse("FDW_PASSWORD", "1234")
+  private val username = sys.env.getOrElse("FDW_USERNAME", "newbie")
+  private val password = sys.env.getOrElse("FDW_PASSWORD", "")
 
   property("raw.creds.jdbc.fdw.host", hostname)
   property("raw.creds.jdbc.fdw.port", port)

--- a/sql-client/src/test/scala/raw/client/sql/TestSqlCompilerServiceAirports.scala
+++ b/sql-client/src/test/scala/raw/client/sql/TestSqlCompilerServiceAirports.scala
@@ -37,11 +37,11 @@ class TestSqlCompilerServiceAirports
 
   private var compilerService: CompilerService = _
 
-  private val database = sys.env.getOrElse("FDW_DATABASE", "unittest")
+  private val database = sys.env.getOrElse("FDW_DATABASE", "raw")
   private val hostname = sys.env.getOrElse("FDW_HOSTNAME", "localhost")
   private val port = sys.env.getOrElse("FDW_HOSTNAME", "5432")
-  private val username = sys.env.getOrElse("FDW_USERNAME", "postgres")
-  private val password = sys.env.getOrElse("FDW_PASSWORD", "1234")
+  private val username = sys.env.getOrElse("FDW_USERNAME", "newbie")
+  private val password = sys.env.getOrElse("FDW_PASSWORD", "")
 
   property("raw.creds.jdbc.fdw.host", hostname)
   property("raw.creds.jdbc.fdw.port", port)


### PR DESCRIPTION
This is implemented using a postgres _temporary table_ that is created/cleaned at startup of each query, and filled when scopes are provided. An example query that is then possible:
```sql
SELECT
    CASE WHEN 'dev' IN (SELECT * FROM scopes) THEN trip_id END AS trip_id,
    departure_date,
    arrival_date
FROM example.trips
```
When `"dev"` is in the scopes:
```json
[
  {
    "trip_id": 0,
    "departure_date": "2016-02-27",
    "arrival_date": "2016-03-06"
  },
  {
    "trip_id": 1,
    "departure_date": "2016-04-10",
    "arrival_date": "2016-04-17"
  },
  {
    "trip_id": 2,
    "departure_date": "2016-05-22",
    "arrival_date": "2016-05-29"
  },
  {
    "trip_id": 3,
    "departure_date": "2023-01-01",
    "arrival_date": "2023-01-01"
  }
]
```
When it's not:
```json
[
  {
    "trip_id": null,
    "departure_date": "2016-02-27",
    "arrival_date": "2016-03-06"
  },
  {
    "trip_id": null,
    "departure_date": "2016-04-10",
    "arrival_date": "2016-04-17"
  },
  {
    "trip_id": null,
    "departure_date": "2016-05-22",
    "arrival_date": "2016-05-29"
  },
  {
    "trip_id": null,
    "departure_date": "2023-01-01",
    "arrival_date": "2023-01-01"
  }
]
```
Another one:
```sql
SELECT 'DEV' IN (SELECT * FROM scopes) AS isDev,
       'ADMIN' IN (SELECT token FROM scopes) AS isAdmin
```
when only `ADMIN` is listed:
```json
[{"isdev":false,"isadmin":true}]
```