### PR TITLE
refactor(publish): publish to ghr

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -37,11 +37,6 @@ jobs:
         fetch-depth: 0
     - name: build all
       run: ./rebuild.sh
-    - name: Import GPG key
-      uses: crazy-max/ghaction-import-gpg@v6
-      with:
-        gpg_private_key: ${{ secrets.PGP_SECRET }}
-        passphrase: ${{ secrets.PGP_PASSPHRASE }}
     - name: sbt ci-release
       run: |
         export HOME="/home/sbtuser"
@@ -50,7 +45,7 @@ jobs:
         yes n | sdk install java 21.0.1-graalce || true
         sdk use java 21.0.1-graalce
         echo "$SDKMAN_DIR/candidates/java/current/bin" >> $GITHUB_PATH
-        sbt clean publishSigned
+        sbt clean publish
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: evaluate produced version

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,6 +6,11 @@ on:
   push:
     tags:
       - "v*.*.*"
+
+permissions:
+  contents: read    # This is required for actions/checkout
+  packages: write
+
 jobs:
   publish-snapi-components:
     runs-on: self-hosted
@@ -32,6 +37,11 @@ jobs:
         fetch-depth: 0
     - name: build all
       run: ./rebuild.sh
+    - name: Import GPG key
+      uses: crazy-max/ghaction-import-gpg@v6
+      with:
+        gpg_private_key: ${{ secrets.PGP_SECRET }}
+        passphrase: ${{ secrets.PGP_PASSPHRASE }}
     - name: sbt ci-release
       run: |
         export HOME="/home/sbtuser"
@@ -40,15 +50,9 @@ jobs:
         yes n | sdk install java 21.0.1-graalce || true
         sdk use java 21.0.1-graalce
         echo "$SDKMAN_DIR/candidates/java/current/bin" >> $GITHUB_PATH
-        sbt ci-release
+        sbt clean publishSigned
       env:
-        SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-        SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-        PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-        PGP_SECRET: ${{ secrets.PGP_SECRET }}
-        CI_CLEAN: clean
-        CI_RELEASE: publishSigned
-        CI_SNAPSHOT_RELEASE: publish
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: evaluate produced version
       shell: bash
       run: echo "VERSION=$(cat ./version)" >> $GITHUB_ENV

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,9 +7,8 @@ on:
     tags:
       - "v*.*.*"
 
-permissions:
-  contents: read    # This is required for actions/checkout
-  packages: write
+env:
+  GITHUB_TOKEN: ${{ secrets.WRITE_PACKAGES }}
 
 jobs:
   publish-snapi-components:
@@ -44,8 +43,6 @@ jobs:
         sdk use java 21.0.1-graalce
         echo "$SDKMAN_DIR/candidates/java/current/bin" >> $GITHUB_PATH
         sbt clean publish
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: evaluate produced version
       shell: bash
       run: echo "VERSION=$(cat ./version)" >> $GITHUB_ENV

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -35,8 +35,6 @@ jobs:
       with:
         ref: ${{ github.event.client_payload.pull_request.head.sha }}
         fetch-depth: 0
-    - name: build all
-      run: ./rebuild.sh
     - name: sbt ci-release
       run: |
         export HOME="/home/sbtuser"

--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ ThisBuild / credentials += Credentials(
   sys.env.getOrElse("GITHUB_TOKEN", "")
 )
 
-ThisBuild/ resolvers += "Github RAW main repo" at "https://maven.pkg.github.com/raw-labs/raw"
+ThisBuild/ resolvers += "Github RAW main repo" at "https://maven.pkg.github.com/raw-labs/snapi"
 
 
 val writeVersionToFile = taskKey[Unit]("Writes the project version to a file at the root.")

--- a/build.sbt
+++ b/build.sbt
@@ -24,9 +24,7 @@ ThisBuild / credentials += Credentials(
   "raw-labs",
   sys.env.getOrElse("GITHUB_TOKEN", "")
 )
-
-ThisBuild/ resolvers += "Github RAW main repo" at "https://maven.pkg.github.com/raw-labs/snapi"
-
+ThisBuild/ resolvers += "Github RAW main repo" at "https://maven.pkg.github.com/raw-labs/raw"
 
 val writeVersionToFile = taskKey[Unit]("Writes the project version to a file at the root.")
 

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -29,7 +29,7 @@ object BuildSettings {
     publish / skip := false,
     publishSigned / skip  := false,
     publishLocal / skip := false,
-    publishTo := Some("GitHub raw-labs Apache Maven Packages" at "https://maven.pkg.github.com/raw-labs/snapi"),
+    publishTo := Some("GitHub raw-labs Apache Maven Sanpi Packages" at "https://maven.pkg.github.com/raw-labs/snapi"),
     publishMavenStyle := true,
     versionScheme := Some("early-semver")
   )

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -28,7 +28,9 @@ object BuildSettings {
     updateOptions := updateOptions.in(Global).value.withCachedResolution(true),
     publish / skip := false,
     publishSigned / skip  := false,
-    publishLocal / skip := false
+    publishLocal / skip := false,
+    publishTo := Some("GitHub raw-labs Apache Maven Packages" at "https://maven.pkg.github.com/raw-labs/raw"),
+    publishMavenStyle := true
   )
 
   lazy val commonCompileSettings = Seq(

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -30,7 +30,8 @@ object BuildSettings {
     publishSigned / skip  := false,
     publishLocal / skip := false,
     publishTo := Some("GitHub raw-labs Apache Maven Packages" at "https://maven.pkg.github.com/raw-labs/snapi"),
-    publishMavenStyle := true
+    publishMavenStyle := true,
+    versionScheme := Some("early-semver")
   )
 
   lazy val commonCompileSettings = Seq(

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -29,7 +29,7 @@ object BuildSettings {
     publish / skip := false,
     publishSigned / skip  := false,
     publishLocal / skip := false,
-    publishTo := Some("GitHub raw-labs Apache Maven Packages" at "https://maven.pkg.github.com/raw-labs/raw"),
+    publishTo := Some("GitHub raw-labs Apache Maven Packages" at "https://maven.pkg.github.com/raw-labs/snapi"),
     publishMavenStyle := true
   )
 


### PR DESCRIPTION
Since latest Sonatype infra migration, the current usage of `sbt-ci-release` plugin is not working anymore
We might still face this issue until https://github.com/sbt/sbt-ci-release/issues/294 is solved,
To cope with this we publish packages to Github Apache Maven