### PR TITLE
merge main

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,6 +6,10 @@ on:
   push:
     tags:
       - "v*.*.*"
+
+env:
+  GITHUB_TOKEN: ${{ secrets.WRITE_PACKAGES }}
+
 jobs:
   publish-snapi-components:
     runs-on: self-hosted
@@ -30,8 +34,6 @@ jobs:
       with:
         ref: ${{ github.event.client_payload.pull_request.head.sha }}
         fetch-depth: 0
-    - name: build all
-      run: ./rebuild.sh
     - name: sbt ci-release
       run: |
         export HOME="/home/sbtuser"
@@ -40,15 +42,7 @@ jobs:
         yes n | sdk install java 21.0.1-graalce || true
         sdk use java 21.0.1-graalce
         echo "$SDKMAN_DIR/candidates/java/current/bin" >> $GITHUB_PATH
-        sbt ci-release
-      env:
-        SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-        SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-        PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-        PGP_SECRET: ${{ secrets.PGP_SECRET }}
-        CI_CLEAN: clean
-        CI_RELEASE: publishSigned
-        CI_SNAPSHOT_RELEASE: publish
+        sbt clean publish
     - name: evaluate produced version
       shell: bash
       run: echo "VERSION=$(cat ./version)" >> $GITHUB_ENV

--- a/build.sbt
+++ b/build.sbt
@@ -24,9 +24,7 @@ ThisBuild / credentials += Credentials(
   "raw-labs",
   sys.env.getOrElse("GITHUB_TOKEN", "")
 )
-
 ThisBuild/ resolvers += "Github RAW main repo" at "https://maven.pkg.github.com/raw-labs/raw"
-
 
 val writeVersionToFile = taskKey[Unit]("Writes the project version to a file at the root.")
 

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -28,7 +28,10 @@ object BuildSettings {
     updateOptions := updateOptions.in(Global).value.withCachedResolution(true),
     publish / skip := false,
     publishSigned / skip  := false,
-    publishLocal / skip := false
+    publishLocal / skip := false,
+    publishTo := Some("GitHub raw-labs Apache Maven Sanpi Packages" at "https://maven.pkg.github.com/raw-labs/snapi"),
+    publishMavenStyle := true,
+    versionScheme := Some("early-semver")
   )
 
   lazy val commonCompileSettings = Seq(


### PR DESCRIPTION
Since latest Sonatype infra migration, the current usage of
`sbt-ci-release` plugin is not working anymore
We might still face this issue until
https://github.com/sbt/sbt-ci-release/issues/294 is solved,
To cope with this we publish packages to Github Apache Maven