### PR TITLE
RD-11080: SqlCompiler crashes when a query is made of 100% comments

### DIFF
--- a/sql-client/src/test/scala/raw/client/sql/TestSqlCompilerServiceAirports.scala
+++ b/sql-client/src/test/scala/raw/client/sql/TestSqlCompilerServiceAirports.scala
@@ -936,11 +936,22 @@ class TestSqlCompilerServiceAirports
     )
   }
 
-  test(
-    """-- @param p
-      |-- @type p integer
-      |-- SELECT :p + 10;
-      |""".stripMargin) { t =>
+  test("""-- @param p
+    |-- @type p integer
+    |-- SELECT :p + 10;
+    |""".stripMargin) { t =>
+    val v = compilerService.validate(t.q, asJson())
+    assert(v.messages.size == 1)
+    assert(v.messages(0).message == "non-executable code")
+  }
+
+  test("""CREATE TABLE Persons (
+    |    ID int NOT NULL,
+    |    LastName varchar(255) NOT NULL,
+    |    FirstName varchar(255),
+    |    Age int,
+    |    PRIMARY KEY (ID)
+    |);""".stripMargin) { t =>
     val v = compilerService.validate(t.q, asJson())
     assert(v.messages.size == 1)
     assert(v.messages(0).message == "non-executable code")

--- a/sql-client/src/test/scala/raw/client/sql/TestSqlCompilerServiceAirports.scala
+++ b/sql-client/src/test/scala/raw/client/sql/TestSqlCompilerServiceAirports.scala
@@ -935,4 +935,14 @@ class TestSqlCompilerServiceAirports
         == """[{"trip_id":0,"departure_date":"2016-02-27","arrival_date":"2016-03-06"}]"""
     )
   }
+
+  test(
+    """-- @param p
+      |-- @type p integer
+      |-- SELECT :p + 10;
+      |""".stripMargin) { t =>
+    val v = compilerService.validate(t.q, asJson())
+    assert(v.messages.size == 1)
+    assert(v.messages(0).message == "non-executable code")
+  }
 }


### PR DESCRIPTION
What is to be discussed here is: how to report that error? Technically the whole source code is failed, because no executable is found (that is the current patch). But underlining the whole code as people peacefully type a comment at the top, isn't convenient. Also, even an empty file should trigger an error?

Or can we underline the _end_ (last character) saying the SELECT statement is missing.

Or can we not report anything as a failure, e.g. `GetProgramDescription` would contain no errors, but also no "final executable", and fail only upon running? (Just thinking of this now.)