### PR TITLE
RD-11232 sql compiler crash parser computes a wrong line col

### DIFF
--- a/sql-client/src/main/scala/raw/client/sql/antlr4/RawSqlSyntaxAnalyzer.scala
+++ b/sql-client/src/main/scala/raw/client/sql/antlr4/RawSqlSyntaxAnalyzer.scala
@@ -26,9 +26,8 @@ class RawSqlSyntaxAnalyzer(val positions: Positions) extends Parsers(positions) 
     val source = StringSource(s)
     val rawErrorListener = new RawSqlErrorListener()
 
-    val striped = s.stripTrailing()
-    val withoutNewLine = if(striped.endsWith("\n")) striped.substring(0, striped.length - 1) else striped
-    val lexer = new PsqlLexer(CharStreams.fromString(withoutNewLine))
+    val striped = s.stripTrailing().stripSuffix("\r\n").stripSuffix("\n").stripSuffix("\r")
+    val lexer = new PsqlLexer(CharStreams.fromString(striped))
     lexer.removeErrorListeners()
     lexer.addErrorListener(rawErrorListener)
 

--- a/sql-client/src/main/scala/raw/client/sql/antlr4/RawSqlSyntaxAnalyzer.scala
+++ b/sql-client/src/main/scala/raw/client/sql/antlr4/RawSqlSyntaxAnalyzer.scala
@@ -26,7 +26,9 @@ class RawSqlSyntaxAnalyzer(val positions: Positions) extends Parsers(positions) 
     val source = StringSource(s)
     val rawErrorListener = new RawSqlErrorListener()
 
-    val lexer = new PsqlLexer(CharStreams.fromString(s))
+    val striped = s.stripTrailing()
+    val withoutNewLine = if(striped.endsWith("\n")) striped.substring(0, striped.length - 1) else striped
+    val lexer = new PsqlLexer(CharStreams.fromString(withoutNewLine))
     lexer.removeErrorListeners()
     lexer.addErrorListener(rawErrorListener)
 

--- a/sql-client/src/main/scala/raw/client/sql/antlr4/RawSqlSyntaxAnalyzer.scala
+++ b/sql-client/src/main/scala/raw/client/sql/antlr4/RawSqlSyntaxAnalyzer.scala
@@ -26,7 +26,7 @@ class RawSqlSyntaxAnalyzer(val positions: Positions) extends Parsers(positions) 
     val source = StringSource(s)
     val rawErrorListener = new RawSqlErrorListener()
 
-    val striped = s.stripTrailing().stripSuffix("\r\n").stripSuffix("\n").stripSuffix("\r")
+    val striped = s.stripTrailing()
     val lexer = new PsqlLexer(CharStreams.fromString(striped))
     lexer.removeErrorListeners()
     lexer.addErrorListener(rawErrorListener)

--- a/sql-client/src/test/scala/raw/client/sql/TestSqlParser.scala
+++ b/sql-client/src/test/scala/raw/client/sql/TestSqlParser.scala
@@ -624,4 +624,31 @@ class TestSqlParser extends AnyFunSuite {
     }
   }
 
+  test("newline after comment") {
+    val code = """select
+      |  id,
+      |  key,
+      |  summary,
+      |  project_key,
+      |  status,
+      |  assignee_display_name,
+      |  assignee_account_id
+      |from
+      |  "jira-danai".jira_backlog_issue
+      |  limit 2
+      |--where
+      |-- assignee_display_name = 'yann';
+      | """.stripMargin
+    val result = doTest(code)
+    checkStartEnd(result)
+  }
+
+  private def checkStartEnd(result: ParseProgramResult) = {
+    val SqlProgramNode(stmt) = result.tree
+    assert(result.positions.getStart(stmt).isDefined)
+    assert(result.positions.getFinish(stmt).isDefined)
+    assert(result.positions.getStart(stmt).flatMap(_.optOffset).isDefined)
+    assert(result.positions.getFinish(stmt).flatMap(_.optOffset).isDefined)
+  }
+
 }


### PR DESCRIPTION
- Fixed by striping trail and removing the extra new line