### PR TITLE
RD-11199: ClassCastException between ErrorExp and Exp

### DIFF
--- a/snapi-frontend/src/main/scala/raw/compiler/rql2/antlr4/RawSnapiVisitor.scala
+++ b/snapi-frontend/src/main/scala/raw/compiler/rql2/antlr4/RawSnapiVisitor.scala
@@ -319,7 +319,7 @@ class RawSnapiVisitor(
         .getOrElse((IdnDef(""), Option.empty))
 
       val exp =
-        Option(context.expr()).map(exprContext => Option(visit(exprContext)).getOrElse(ErrorExp).asInstanceOf[Exp])
+        Option(context.expr()).map(exprContext => Option(visit(exprContext)).getOrElse(ErrorExp()).asInstanceOf[Exp])
 
       val result = FunParam(
         tupple._1,
@@ -347,7 +347,7 @@ class RawSnapiVisitor(
     .flatMap { context =>
       Option(context.expr()).map { exprContext =>
         val result: FunAppArg =
-          FunAppArg(Option(visit(exprContext)).getOrElse(ErrorExp).asInstanceOf[Exp], Option.empty)
+          FunAppArg(Option(visit(exprContext)).getOrElse(ErrorExp()).asInstanceOf[Exp], Option.empty)
         positionsWrapper.setPosition(context, result)
         result
       }

--- a/snapi-frontend/src/test/scala/raw/compiler/rql2/Antlr4LSPTests.scala
+++ b/snapi-frontend/src/test/scala/raw/compiler/rql2/Antlr4LSPTests.scala
@@ -228,4 +228,12 @@ class Antlr4LSPTests extends RawTestSuite {
     )
   }
 
+  test("RD11199") { _ =>
+    val prog = "Collection.Transform(Int.Range(1, 100000), -="
+    val result = parseWithAntlr4(prog)
+    assert(
+      result.errors(0).message == "the input does not form a valid statement or expression."
+    )
+  }
+
 }


### PR DESCRIPTION
I believe the mistake is `ErrorExp` (the class) instead of `ErrorExp()`, an instance. `ErrorExp` cannot be cast to class `Exp` as if it was an instance. The crash occurs without the fix.

I noticed another place in the visitor where the fix should be made, but I couldn't come up with any snapi code that would hit it (one needs an `ErrorExp` in place of a function parameter default value).