### PR TITLE
RD-11280: Typo in query triggers a `schema does not exist` error

### DIFF
--- a/sql-client/src/main/scala/raw/client/sql/NamedParametersPreparedStatement.scala
+++ b/sql-client/src/main/scala/raw/client/sql/NamedParametersPreparedStatement.scala
@@ -566,7 +566,7 @@ class NamedParametersPreparedStatement(
   }
 
   private def asErrorString(ex: PSQLException): Option[String] = {
-    if (Set("42", "22", "0A").exists(ex.getSQLState.startsWith)) {
+    if (Set("42", "22", "0A", "3F").exists(ex.getSQLState.startsWith)) {
       // syntax error / semantic error
       val psqlError = Option(ex.getServerErrorMessage) // getServerErrorMessage can be null!
       val error = psqlError.map(_.getMessage).getOrElse(ex.getMessage)

--- a/sql-client/src/test/scala/raw/client/sql/TestSqlCompilerServiceAirports.scala
+++ b/sql-client/src/test/scala/raw/client/sql/TestSqlCompilerServiceAirports.scala
@@ -956,4 +956,17 @@ class TestSqlCompilerServiceAirports
     assert(v.messages.size == 1)
     assert(v.messages(0).message == "non-executable code")
   }
+
+  test("""select
+    |  airport_id,
+    |  city,
+    |  country.name 'cname'
+    |from
+    |  example.airports
+    |limit 10;
+    |""".stripMargin) { t =>
+    val v = compilerService.validate(t.q, asJson())
+    assert(v.messages.size == 1)
+    assert(v.messages(0).message == "schema \"country\" does not exist")
+  }
 }


### PR DESCRIPTION
It should be reported to the user. Note the query is a little peculiar: in place of an alias column name, the person entered a single quoted string (a regular string). With a regular identifier the error doesn't occur.