### PR TITLE
RD-12433: Test that assert Http URL parsing is correctly handling arguments

### DIFF
--- a/snapi-compiler/src/test/scala/com/rawlabs/snapi/compiler/tests/builtin/HttpPackageTest.scala
+++ b/snapi-compiler/src/test/scala/com/rawlabs/snapi/compiler/tests/builtin/HttpPackageTest.scala
@@ -394,6 +394,22 @@ class HttpPackageTest extends SnapiTestContext {
     |)
     |""".stripMargin)(_ should evaluateTo("\"a=12&b=13\""))
 
+  // Arguments in the URL are correctly handled.
+  test(s"""String.Read("http://localhost:$testPort/return-args?a=12&b=13")
+    |""".stripMargin)(_ should evaluateTo("\"a=12&b=13\""))
+
+  // Arguments in the URL + passed as an array to Http.Get, are correctly handled.
+  test(s"""String.Read(Http.Get("http://localhost:$testPort/return-args?a=12", args=[{"b", "13"}]))
+    |""".stripMargin)(_ should evaluateTo("\"a=12&b=13\""))
+
+  // Syntax error.
+  test(s"""String.Read("http//localhost:$testPort/return-args?a=&b=13")
+    |""".stripMargin)(_ should runErrorAs("unsupported protocol: http//localhost"))
+
+  // Syntax error.
+  test(s"""String.Read("htp://localhost:$testPort/return-args?a=&b=13")
+    |""".stripMargin)(_ should runErrorAs("unsupported protocol: htp"))
+
   test(s"""String.Read(Http.Get(
     |  "http://localhost:$testPort/return-args",
     |  args=[{"a", "12"}, {"b", null}, {"c", "14"}])

--- a/snapi-frontend/src/main/scala/com/rawlabs/snapi/frontend/snapi/extensions/LocationDescription.scala
+++ b/snapi-frontend/src/main/scala/com/rawlabs/snapi/frontend/snapi/extensions/LocationDescription.scala
@@ -551,9 +551,7 @@ object LocationDescription {
 
     // Parse the URL based on the protocol.
     protocol match {
-      case "http" | "https" =>
-        // FIXME: This is ignoring query parameters!!!
-        Right(
+      case "http" | "https" => Right(
           HttpByteStreamLocationDescription(
             url,
             method = "GET",


### PR DESCRIPTION
The added `HttpPackageTest` tests passing args are passing. Because we pass the URL to a library which figures out. The most challenging one is where half of the args is passed in the URL, and the other half as a formal list of arguments, they're merged because the library sorts it out.

Hence I remove the "TODO" comment that was in the code since there's nothing to do (?)

Also added a CSV test making sure we correctly handle a mistakenly passed directory (in place of a file).