### PR TITLE
docs: correct links and change phrase

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Here is an overview of each component:
 * `snapi-frontend`: This includes the compiler frontend, e.g. parser, type checker, pretty printers, etc for the Snapi language;
 * `snapi-truffle`: This includes the implementation of the Snapi language in Truffle.
 * `snapi-client`: This implements the `client` interface using the Snapi Truffle backend engine.
-* `python-client`: This is an early-preview of the Python support for the [RAW Platform](https://www.raw-labs.com/). Effectively, it implements `client` interface using the [GraalPy][https://github.com/oracle/graalpython) implementation.
+* `python-client`: This is an early-preview of the Python support for the [RAW Platform](https://www.raw-labs.com/). Effectively, it implements `client` interface using the [GraalPy](https://github.com/oracle/graalpython) implementation.
 * `launcher`: A simple CLI implementation against the `client` interface. By default it runs with the Snapi language.
 * `utils: Some common utils shared among components.
 
@@ -250,7 +250,7 @@ Before starting:
 To setup the project in Intellij, we recommend cloning the repo and opening it with "Import project from existing sources".
 You can choose to import as an "SBT" project, but we found that "BSP" with "SBT" also works well.
 "SBT" with "Shell for importing building" is also recommended.
-Reach out to us (Discord)[https://discord.com/invite/AwFHYThJeh] if you have issues setting up the project.
+Reach out to us [Discord](https://discord.com/invite/AwFHYThJeh) if you have issues setting up the project.
 
 If Intellij prompts you to use 'scalafmt', say "Yes" as this is our code formatter.
 

--- a/README.md
+++ b/README.md
@@ -250,7 +250,8 @@ Before starting:
 To setup the project in Intellij, we recommend cloning the repo and opening it with "Import project from existing sources".
 You can choose to import as an "SBT" project, but we found that "BSP" with "SBT" also works well.
 "SBT" with "Shell for importing building" is also recommended.
-Reach out to us [Discord](https://discord.com/invite/AwFHYThJeh) if you have issues setting up the project.
+
+If you have issues setting up the project, reach out to us on [Discord](https://discord.com/invite/AwFHYThJeh).
 
 If Intellij prompts you to use 'scalafmt', say "Yes" as this is our code formatter.
 


### PR DESCRIPTION
This PR fixes the Markdown links.

Also, took the liberty to change a phrase and make it a paragraph.

---

Before:

![Screenshot 2024-08-23 at 4 38 16 PM](https://github.com/user-attachments/assets/06a55a7c-48a7-4aeb-aacc-0091d96f0242)
![Screenshot 2024-08-23 at 4 38 27 PM](https://github.com/user-attachments/assets/d1ecd8fc-c252-4283-8cb8-0470ce496d62)

After:

![Screenshot 2024-08-23 at 4 36 14 PM](https://github.com/user-attachments/assets/f9110351-7bee-463a-ba28-5465bbabc1df)
![Screenshot 2024-08-23 at 4 35 53 PM](https://github.com/user-attachments/assets/02b815b3-6dfe-4728-86db-17953df21401)

Preview: https://github.com/steenzout/snapi/blob/steenzout-readme-20240823/README.md

---

👋🏻 