### PR TITLE
RD-12419: Added retry to SqlConnectionPool

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -299,9 +299,9 @@ lazy val sqlCompiler = (project in file("sql-compiler"))
       kiama,
       postgresqlDeps,
       hikariCP,
-      "com.dimafeng" %% "testcontainers-scala-scalatest" % "0.41.3" % Test,
-      "com.dimafeng" %% "testcontainers-scala-postgresql" % "0.41.3" % Test,
-      "org.testcontainers" % "toxiproxy" % "1.19.8" % Test
+      "com.dimafeng" %% "testcontainers-scala-scalatest" % "0.41.4" % Test,
+      "com.dimafeng" %% "testcontainers-scala-postgresql" % "0.41.4" % Test,
+      "org.testcontainers" % "toxiproxy" % "1.20.1" % Test
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -300,7 +300,8 @@ lazy val sqlCompiler = (project in file("sql-compiler"))
       postgresqlDeps,
       hikariCP,
       "com.dimafeng" %% "testcontainers-scala-scalatest" % "0.41.3" % Test,
-      "com.dimafeng" %% "testcontainers-scala-postgresql" % "0.41.3" % Test
+      "com.dimafeng" %% "testcontainers-scala-postgresql" % "0.41.3" % Test,
+      "org.testcontainers" % "toxiproxy" % "1.19.8" % Test
     )
   )
 

--- a/sql-compiler/src/main/resources/reference.conf
+++ b/sql-compiler/src/main/resources/reference.conf
@@ -1,7 +1,4 @@
 raw.sql.compiler {
-  error-messages {
-     missing-relation = "Did you forget to add credentials?"
-  }
   metadata-cache {
     size = 1000 # How many individual user metadata caches to keep
     duration = 30m # How long to keep user metadata data cache

--- a/sql-compiler/src/main/resources/reference.conf
+++ b/sql-compiler/src/main/resources/reference.conf
@@ -11,5 +11,7 @@ raw.sql.compiler {
     idle-timeout = 20m # How long before a connection is considered to be idle (for GC or for checking health)
     health-check-period = 5s # How often to check for health of connections
     is-valid-seconds = 5 # Controls the JDBC isValid(seconds) setting to use. Apparently 5 is a common value.
+    retry-interval = 0.5 seconds # How long to wait and reconnect when an operation against FDW fails.
+    retries = 9 # How many retries when an operation against FDW fails (zero = we try but don't retry upon failure)
   }
 }

--- a/sql-compiler/src/main/scala/com/rawlabs/sql/compiler/SqlConnectionPool.scala
+++ b/sql-compiler/src/main/scala/com/rawlabs/sql/compiler/SqlConnectionPool.scala
@@ -273,7 +273,6 @@ class SqlConnectionPool()(implicit settings: RawSettings) extends RawService wit
     }
   }
 
-  @throws[CompilerServiceException]
   def connectAnd[T](jdbcUrl: String)(what: Connection => T): T = {
     var i = 0;
     var throwable: Throwable = null

--- a/sql-compiler/src/test/scala/com/rawlabs/sql/compiler/StressTest.scala
+++ b/sql-compiler/src/test/scala/com/rawlabs/sql/compiler/StressTest.scala
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2024 RAW Labs S.A.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0, included in the file
+ * licenses/APL.txt.
+ */
+
+package raw.client.sql
+
+import com.dimafeng.testcontainers.PostgreSQLContainer
+import eu.rekawek.toxiproxy.model.ToxicDirection
+import eu.rekawek.toxiproxy.{Proxy, ToxiproxyClient}
+import org.scalatest.matchers.must.Matchers.{be, noException}
+import org.testcontainers.containers.{Network, ToxiproxyContainer}
+import org.testcontainers.utility.DockerImageName
+import raw.client.api._
+import raw.utils._
+
+import java.io.{ByteArrayOutputStream, IOException}
+import java.sql.DriverManager
+import java.util.concurrent.Executors
+import scala.io.Source
+
+class StressTest extends RawTestSuite with SettingsTestContext with TrainingWheelsContext {
+
+  private var container: PostgreSQLContainer = _
+  Class.forName("org.postgresql.Driver")
+
+  private var network: Network = _
+  private var toxiproxy: ToxiproxyContainer = _
+  private var proxy: Proxy = _
+
+  private var compilerService: CompilerService = _
+  private var jdbcUrl: String = _
+
+  // Username equals the database
+  private val user = InteractiveUser(Uid("blah"), "fdw user", "email", Seq.empty)
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    network = Network.newNetwork()
+    container = PostgreSQLContainer(
+      dockerImageNameOverride = DockerImageName.parse("postgres:15-alpine")
+    ).configure(_.withNetwork(network)).configure(_.withNetworkAliases("pgpg"))
+
+    container.start()
+
+    val conn = DriverManager.getConnection(container.jdbcUrl, container.username, container.password);
+    val resource = Source.fromResource("example.sql")
+    val sql =
+      try {
+        resource.mkString
+      } finally {
+        resource.close()
+      }
+
+    val stmt = conn.createStatement()
+    stmt.execute(sql)
+
+    toxiproxy = new ToxiproxyContainer("ghcr.io/shopify/toxiproxy:2.5.0").withNetwork(network)
+    toxiproxy.start()
+    val toxiproxyClient = new ToxiproxyClient(toxiproxy.getHost, toxiproxy.getControlPort)
+    proxy = toxiproxyClient.createProxy("db", "0.0.0.0:8666", s"pgpg:5432")
+    jdbcUrl = {
+      val dbPort = toxiproxy.getMappedPort(8666).toString
+      val dbName = container.databaseName
+      val user = container.username
+      val password = container.password
+      s"jdbc:postgresql://${toxiproxy.getHost}:$dbPort/$dbName?user=$user&password=$password"
+    }
+    compilerService = {
+      new SqlCompilerService()
+    }
+    env = ProgramEnvironment(
+      user,
+      Some(Array("city" -> RawString("Lyon"))),
+      Set.empty,
+      Map("output-format" -> "json"),
+      None,
+      Some(jdbcUrl)
+    )
+  }
+
+  override def afterAll(): Unit = {
+    if (compilerService != null) {
+      compilerService.stop()
+      compilerService = null
+    }
+    Option(proxy).foreach(_.delete)
+    proxy = null
+    Option(toxiproxy).foreach(_.stop)
+    toxiproxy = null
+    Option(container).foreach(_.stop)
+    container = null
+    Option(network).foreach(_.close)
+    network = null
+    super.afterAll()
+  }
+
+  private def withFailures(what: () => Unit): Unit = {
+    val executor = Executors.newSingleThreadExecutor()
+    val bugFunctions = Seq(
+      () => proxy.toxics().timeout("bug", ToxicDirection.UPSTREAM, 0),
+      () => proxy.toxics().timeout("bug", ToxicDirection.DOWNSTREAM, 0),
+      () => proxy.toxics().resetPeer("bug", ToxicDirection.UPSTREAM, 0),
+      () => proxy.toxics().resetPeer("bug", ToxicDirection.DOWNSTREAM, 0)
+    )
+    val failures = executor.submit(() => {
+      for (i <- 1 to 2; installBug <- bugFunctions) {
+        Thread.sleep(2000)
+        installBug()
+        logger.warn("enable bug")
+        Thread.sleep(3000)
+        proxy.toxics().get("bug").remove()
+        logger.warn("disable bug")
+      }
+      12
+    })
+    try {
+      for (i <- 1 to 500) {
+        logger.debug(s"#$i")
+        noException should be thrownBy what()
+      }
+    } finally {
+      failures.cancel(true)
+      try {
+        proxy.toxics().get("bug").remove()
+      } catch {
+        case _: IOException => // normal if not existing
+      }
+      executor.close()
+    }
+  }
+
+  private var env: ProgramEnvironment = _
+  private val code = "SELECT COUNT(*) FROM example.airports WHERE city = :city"
+
+  test("getProgramDescription") { _ =>
+    withFailures { () =>
+      val GetProgramDescriptionSuccess(_) = compilerService.getProgramDescription(code, env)
+      Thread.sleep(10)
+    }
+  }
+
+  test("dotAutoComplete") { _ =>
+    withFailures { () =>
+      val AutoCompleteResponse(r) = compilerService.dotAutoComplete(code, env, Pos(1, 30))
+      assert(r.nonEmpty) // example.airports columns
+      Thread.sleep(10)
+    }
+  }
+
+  test("wordAutoComplete") { _ =>
+    withFailures { () =>
+      val AutoCompleteResponse(r) = compilerService.wordAutoComplete(code, env, "ex", Pos(1, 24))
+      assert(r.nonEmpty) // example.airports columns
+      Thread.sleep(10)
+    }
+  }
+
+  test("hover") { _ =>
+    withFailures { () =>
+      val HoverResponse(r) = compilerService.hover(code, env, Pos(1, 24))
+      assert(r.nonEmpty)
+      Thread.sleep(10)
+    }
+  }
+
+  test("validate") { _ =>
+    withFailures { () =>
+      val ValidateResponse(r) = compilerService.validate(code, env)
+      assert(r.isEmpty)
+      Thread.sleep(10)
+    }
+  }
+
+  ignore("execute") { _ =>
+    val outputStream = new ByteArrayOutputStream()
+    try {
+      withFailures { () =>
+        val r = compilerService.execute(code, env, None, outputStream, None)
+        assert(r.isInstanceOf[ExecutionSuccess])
+        Thread.sleep(10)
+        outputStream.reset()
+      }
+    } finally {
+      outputStream.close()
+    }
+  }
+
+}

--- a/sql-compiler/src/test/scala/com/rawlabs/sql/compiler/StressTest.scala
+++ b/sql-compiler/src/test/scala/com/rawlabs/sql/compiler/StressTest.scala
@@ -28,6 +28,8 @@ import scala.io.Source
 
 class StressTest extends RawTestSuite with SettingsTestContext with TrainingWheelsContext {
 
+  property("raw.client.sql.metadata-cache.match-validity", "1s")
+
   private var container: PostgreSQLContainer = _
   Class.forName("org.postgresql.Driver")
 

--- a/sql-compiler/src/test/scala/com/rawlabs/sql/compiler/StressTest.scala
+++ b/sql-compiler/src/test/scala/com/rawlabs/sql/compiler/StressTest.scala
@@ -10,16 +10,26 @@
  * licenses/APL.txt.
  */
 
-package raw.client.sql
+package com.rawlabs.sql.compiler
 
 import com.dimafeng.testcontainers.PostgreSQLContainer
+import com.rawlabs.compiler.{
+  AutoCompleteResponse,
+  CompilerService,
+  ExecutionSuccess,
+  GetProgramDescriptionSuccess,
+  HoverResponse,
+  Pos,
+  ProgramEnvironment,
+  RawString,
+  ValidateResponse
+}
+import com.rawlabs.utils.core.{RawTestSuite, RawUid, SettingsTestContext, TrainingWheelsContext}
 import eu.rekawek.toxiproxy.model.ToxicDirection
 import eu.rekawek.toxiproxy.{Proxy, ToxiproxyClient}
 import org.scalatest.matchers.must.Matchers.{be, noException}
 import org.testcontainers.containers.{Network, ToxiproxyContainer}
 import org.testcontainers.utility.DockerImageName
-import raw.client.api._
-import raw.utils._
 
 import java.io.{ByteArrayOutputStream, IOException}
 import java.sql.DriverManager

--- a/sql-compiler/src/test/scala/com/rawlabs/sql/compiler/StressTest.scala
+++ b/sql-compiler/src/test/scala/com/rawlabs/sql/compiler/StressTest.scala
@@ -38,8 +38,7 @@ class StressTest extends RawTestSuite with SettingsTestContext with TrainingWhee
   private var compilerService: CompilerService = _
   private var jdbcUrl: String = _
 
-  // Username equals the database
-  private val user = InteractiveUser(Uid("blah"), "fdw user", "email", Seq.empty)
+  private val user = RawUid("blah")
 
   override def beforeAll(): Unit = {
     super.beforeAll()
@@ -79,9 +78,10 @@ class StressTest extends RawTestSuite with SettingsTestContext with TrainingWhee
     env = ProgramEnvironment(
       user,
       Some(Array("city" -> RawString("Lyon"))),
-      Set.empty,
+      Set.empty, // scopes
+      Map.empty, // secrets
+      Map.empty, // location configs
       Map("output-format" -> "json"),
-      None,
       Some(jdbcUrl)
     )
   }

--- a/sql-compiler/src/test/scala/com/rawlabs/sql/compiler/TestSqlConnectionFailures.scala
+++ b/sql-compiler/src/test/scala/com/rawlabs/sql/compiler/TestSqlConnectionFailures.scala
@@ -63,6 +63,10 @@ class TestSqlConnectionFailures
   )
   Class.forName("org.postgresql.Driver")
 
+  // retrying interferes with the test scenarios. The client
+  // has one chance.
+  property("raw.sql.compiler.pool.retries", "0")
+
   private var users: Set[RawUid] = _
 
   private def jdbcUrl(user: RawUid) = {


### PR DESCRIPTION
An implementation of a connection retry to the SqlConnectionPool.

The patch adds a `connectAnd` API that obtains a connection and passes to the provided handler:
```
def connectAnd[T](jdbcUrl: String)(handler: Connection => T): T
```
It handles the connection failures internally.

Calls that would pick a connection and use it are here switched to that. A test is added that purposely triggers connection failures to the FDW database, using a test container network proxy introducing connection errors that last a couple of seconds. With the patch, calls eventually succeed since `connectAnd` retries and sleeps enough to recover.

One call hasn't been fixed: `execute`, because it is provided with an `OutputStream` to write to, and if it would retry in the middle of its execution, that would lead to a corrupted output.