### PR TITLE
feat: scala-steward conf and mergify for com.raw-labs groupId

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,13 @@
+pull_request_rules:
+  - name: Automatic merge for Scala Steward patch updates from com.raw-labs
+    conditions:
+      - author=scala-steward
+      - label=semver-patch
+      - label=com.raw-labs
+      - check-success=code-checks
+      - check-success=doc
+      - check-success=tests (*)
+      - label!=do not merge
+    actions:
+      merge:
+        method: squash

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,3 +1,16 @@
-updates.limit = 5
+updates.allow = [
+  {
+    groupId = {
+      startsWith = "com.raw-labs"
+    }
+  }
+]
 
-buildRoots = ["extensions", "language"]
+pullRequests = {
+  includeArtifactIds = true
+  title = "Update ${artifactName} to ${nextVersion}"
+  labels = ["dependencies", "scala-steward", "com.raw-labs"]
+  addLabels = {
+    updateTypes = true
+  }
+}


### PR DESCRIPTION
We add scala-steward conf combined with mergify in order to auto-merge patch updates from `com.raw-labs` packages 

it will only have effect once

- [x] https://github.com/VirtusLab/scala-steward-repos/pull/446 is merged