### PR TITLE
RD-14762: SqlCompilerService crashes on default null date parameter

### DIFF
--- a/sql-compiler/src/main/scala/com/rawlabs/sql/compiler/NamedParametersPreparedStatement.scala
+++ b/sql-compiler/src/main/scala/com/rawlabs/sql/compiler/NamedParametersPreparedStatement.scala
@@ -617,25 +617,41 @@ class NamedParametersPreparedStatement(
 
   private def getDefaultValue(rs: ResultSet, postgresType: PostgresType): DefaultValue = {
     assert(rs.next(), "rs.next() was false")
-    val attempt = postgresType.jdbcType match {
-      case java.sql.Types.SMALLINT => RawShort(rs.getShort(1))
-      case java.sql.Types.INTEGER => RawInt(rs.getInt(1))
-      case java.sql.Types.BIGINT => RawLong(rs.getLong(1))
-      case java.sql.Types.DECIMAL => RawDecimal(rs.getBigDecimal(1))
-      case java.sql.Types.FLOAT => RawFloat(rs.getFloat(1))
-      case java.sql.Types.DOUBLE => RawDouble(rs.getDouble(1))
-      case java.sql.Types.DATE => RawDate(rs.getDate(1).toLocalDate)
-      case java.sql.Types.TIME => RawTime(LocalTime.ofNanoOfDay(rs.getTime(1).getTime * 1000000))
-      case java.sql.Types.TIMESTAMP => RawTimestamp(rs.getTimestamp(1).toLocalDateTime)
-      case java.sql.Types.BOOLEAN => RawBool(rs.getBoolean(1))
-      case java.sql.Types.VARCHAR => RawString(rs.getString(1))
+    val value = postgresType.jdbcType match {
+      case java.sql.Types.SMALLINT =>
+        val sqlValue = rs.getShort(1)
+        if (rs.wasNull()) RawNull() else RawShort(sqlValue)
+      case java.sql.Types.INTEGER =>
+        val sqlValue = rs.getInt(1)
+        if (rs.wasNull()) RawNull() else RawInt(sqlValue)
+      case java.sql.Types.BIGINT =>
+        val sqlValue = rs.getLong(1)
+        if (rs.wasNull()) RawNull() else RawLong(sqlValue)
+      case java.sql.Types.DECIMAL =>
+        val sqlValue = rs.getBigDecimal(1)
+        if (rs.wasNull()) RawNull() else RawDecimal(sqlValue)
+      case java.sql.Types.FLOAT =>
+        val sqlValue = rs.getFloat(1)
+        if (rs.wasNull()) RawNull() else RawFloat(sqlValue)
+      case java.sql.Types.DOUBLE =>
+        val sqlValue = rs.getDouble(1)
+        if (rs.wasNull()) RawNull() else RawDouble(sqlValue)
+      case java.sql.Types.DATE =>
+        val sqlValue = rs.getDate(1)
+        if (rs.wasNull()) RawNull() else RawDate(sqlValue.toLocalDate)
+      case java.sql.Types.TIME =>
+        val sqlValue = rs.getTime(1)
+        if (rs.wasNull()) RawNull() else RawTime(LocalTime.ofNanoOfDay(sqlValue.getTime * 1000000))
+      case java.sql.Types.TIMESTAMP =>
+        val sqlValue = rs.getTimestamp(1)
+        if (rs.wasNull()) RawNull() else RawTimestamp(sqlValue.toLocalDateTime)
+      case java.sql.Types.BOOLEAN =>
+        val sqlValue = rs.getBoolean(1)
+        if (rs.wasNull()) RawNull() else RawBool(sqlValue)
+      case java.sql.Types.VARCHAR =>
+        val sqlValue = rs.getString(1)
+        if (rs.wasNull()) RawNull() else RawString(sqlValue)
     }
-    val value =
-      if (rs.wasNull()) {
-        RawNull()
-      } else {
-        attempt
-      }
     DefaultValue(value, postgresType)
   }
 

--- a/sql-compiler/src/test/scala/com/rawlabs/sql/compiler/TestSqlCompilerServiceAirports.scala
+++ b/sql-compiler/src/test/scala/com/rawlabs/sql/compiler/TestSqlCompilerServiceAirports.scala
@@ -27,6 +27,7 @@ import com.rawlabs.compiler.{
   Pos,
   ProgramEnvironment,
   RawAttrType,
+  RawDate,
   RawDateType,
   RawDecimalType,
   RawInt,
@@ -46,6 +47,7 @@ import com.rawlabs.utils.core._
 
 import java.io.ByteArrayOutputStream
 import java.sql.DriverManager
+import java.time.LocalDate
 import scala.io.Source
 
 class TestSqlCompilerServiceAirports
@@ -1079,6 +1081,47 @@ class TestSqlCompilerServiceAirports
       assert(compilerService.execute(t.q, env, None, baos) == ExecutionSuccess(true))
       assert(baos.toString().contains("12:13:14.567"))
     }
+  }
+
+  test("""-- @type x integer
+    |-- @default x null
+    |SELECT :x AS x""".stripMargin) { t =>
+    val baos = new ByteArrayOutputStream()
+    baos.reset()
+    assert(compilerService.execute(t.q, asJson(), None, baos) == ExecutionSuccess(true))
+    assert(baos.toString() === """[{"x":null}]""")
+    baos.reset()
+    assert(compilerService.execute(t.q, asJson(Map("x" -> RawInt(12))), None, baos) == ExecutionSuccess(true))
+    assert(baos.toString() === """[{"x":12}]""")
+  }
+
+  test("""-- @type x varchar
+    |-- @default x null
+    |SELECT :x AS x""".stripMargin) { t =>
+    val baos = new ByteArrayOutputStream()
+    assert(compilerService.execute(t.q, asJson(), None, baos) == ExecutionSuccess(true))
+    assert(baos.toString() === """[{"x":null}]""")
+    baos.reset()
+    assert(compilerService.execute(t.q, asJson(Map("x" -> RawString("tralala"))), None, baos) == ExecutionSuccess(true))
+    assert(baos.toString() === """[{"x":"tralala"}]""")
+  }
+
+  test("""-- @type x date
+    |-- @default x null
+    |SELECT :x AS x""".stripMargin) { t =>
+    val baos = new ByteArrayOutputStream()
+    assert(compilerService.execute(t.q, asJson(), None, baos) == ExecutionSuccess(true))
+    assert(baos.toString() === """[{"x":null}]""")
+    baos.reset()
+    assert(
+      compilerService.execute(
+        t.q,
+        asJson(Map("x" -> RawDate(LocalDate.of(2008, 9, 29)))),
+        None,
+        baos
+      ) == ExecutionSuccess(true)
+    )
+    assert(baos.toString() === """[{"x":"2008-09-29"}]""")
   }
 
 }


### PR DESCRIPTION
Same for `TIME` and `TIMESTAMP`. Other types wouldn't crash, but they end up as e.g. a `RawString` that embeds a `null` string, instead of being a `RawNull`.