### PR TITLE
RD-14898: SqlCompiler crashes when running 'hover' against a query that has two statements

### DIFF
--- a/sql-compiler/src/main/scala/com/rawlabs/sql/compiler/antlr4/SqlVisitor.scala
+++ b/sql-compiler/src/main/scala/com/rawlabs/sql/compiler/antlr4/SqlVisitor.scala
@@ -689,7 +689,10 @@ class SqlVisitor(
         val param = SqlParamUseNode(name)
 
         param match {
-          case use: SqlParamUseNode => params.get(use.name) match {
+          // The first statement is the only one that will be provided and later considered when running/validating
+          // in Postgres. Therefore, we ignore parameters when they don't belong that first statement.
+          case use: SqlParamUseNode if isFirstStatement =>
+            params.get(use.name) match {
               case Some(value) => params.update(use.name, value.copy(occurrences = value.occurrences :+ use))
               case None => params += (use.name -> SqlParam(use.name, None, None, None, Vector.empty, Vector(use)))
             }


### PR DESCRIPTION
What happens is specific to LSP and `hover`.

* LSP calls do not fail when the ANTL4 parser has detected failures because we like to perform completion and the like even with syntax errors.
* Hover has a specificity that if hovering an argument like `:iata`, we need to perform some code semantic analysis to compute the _type_ of the argument. This involves passing the query to postgres to let it do its own inference and checks (sometimes the type is totally inferred by postgres).
* When there are syntax errors, we'll get errors and postgres won't be able to infer, fine. But having two statements isn't always an error (they can be comments) so we just go and try, but _after cutting the code at the first statement_.

The bug we hit is that the parsed tree contains references to arguments like `:iata` when they're located in the second statement, and when we try to construct the postgres query (the one that contains `?` in place of those), we get references to arguments that are in portions of code we don't have (since it was cut).

I could work a first fix where the processing is careful with arguments and ignores those that are outside the code, but that is a little dangerous, there were several places to fix. I thought the parser could just skip those when they wouldn't belong to the first statement.